### PR TITLE
COOK-1105 add runit, bluepill, and daemontools dependencies to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,3 +13,7 @@ recipe            "chef-client::cron", "Runs chef-client as a cron job rather th
 %w{ ubuntu debian redhat centos fedora freebsd openbsd mac_os_x mac_os_x_server windows }.each do |os|
   supports os
 end
+
+depends "runit"
+depends "bluepill"
+depends "daemontools"


### PR DESCRIPTION
add runit, bluepill, and daemontools dependencies to metadata.rb

previously this cookbook would fail to run if these cookbooks were not found on the node
