### PR TITLE
COOK-1191

### DIFF
--- a/templates/default/sv-chef-client-run.erb
+++ b/templates/default/sv-chef-client-run.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin<% if node["languages"]["ruby"]["gems_dir"] %>:<%= node["languages"]["ruby"]["gems_dir"] %>/bin<% end -%>
 exec 2>&1
-exec /usr/bin/env chef-client -i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %>
+exec /usr/bin/env chef-client -i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -L <%= node["chef_client"]["log_dir"] %>/client.log


### PR DESCRIPTION
chef-client cookbook doesn't log to /var/log/chef/client.log when using init_style runit

The sv-chef-client-run.erb template used to pass the -L flag to chef-client back in version 0.99.5 of the cookbook but doesn't in newer versions. Result is chef-client runs via the daemon (runit) don't log their output anywhere.
