### PR TITLE
[COOK-1203] Allow path env variable to be set when running via cron

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default["chef_client"]["conf_dir"]    = "/etc/chef"
 default["chef_client"]["bin"]         = "/usr/bin/chef-client"
 default["chef_client"]["server_url"]  = "http://localhost:4000"
 default["chef_client"]["validation_client_name"] = "chef-validator"
-default["chef_client"]["cron"] = { "minute" => "0", "hour" => "*/4" }
+default["chef_client"]["cron"] = { "minute" => "0", "hour" => "*/4", "path" => nil}
 
 case platform
 when "arch"

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -75,6 +75,7 @@ end
 cron "chef-client" do
   minute node['chef_client']['cron']['minute']	
   hour	node['chef_client']['cron']['hour']
+  path node['chef_client']['cron']['path'] if node['chef_client']['cron']['path']
   user	"root"
   shell	"/bin/bash"
   command "/bin/sleep `/usr/bin/expr $RANDOM \\% 90` &> /dev/null ; #{client_bin} &> /dev/null "


### PR DESCRIPTION
Lets the PATH be optionally defined for chef-client runs via cron
