### PR TITLE
COOK-1359: Call to daemon should execute the chef-client set in $exec

### DIFF
--- a/templates/default/redhat/init.d/chef-client.erb
+++ b/templates/default/redhat/init.d/chef-client.erb
@@ -35,7 +35,7 @@ start() {
     [ -x $exec ] || exit 5
     [ -f $config ] || exit 6
     echo -n $"Starting $prog: "
-    daemon chef-client -d -c "$config" -L "$logfile" -P "$pidfile" -i "$interval" -s "$splay" "$options"
+    daemon $exec -d -c "$config" -L "$logfile" -P "$pidfile" -i "$interval" -s "$splay" "$options"
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile


### PR DESCRIPTION
On Fedora 17 systems, chef-client is bootstrapped and installed in /usr/local/bin, which is not in the system path. This recipe sets $exec correctly within the init script, but $exec is not passed to the call to daemon, so the init script does not work out of the box.
