### PR TITLE
Register chef-client as a launchd service on Mac OS X (Server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Attributes
 * `node["chef_client"]["backup_path"]` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
 * `node["chef_client"]["cron"]["minute"]` - The hour that chef-client will run as a cron task, only applicable if the you set "cron" as the "init_style"
 * `node["chef_client"]["cron"]["hour"]` - The hour that chef-client will run as a cron task, only applicable if the you set "cron" as the "init_style"
+* `node["chef_client"]["launchd_mode"]` - (Only for Mac OS X) if set to "daemon", runs chef-client with `-d` and `-s` options; defaults to "interval"
 
 
 
@@ -233,7 +234,7 @@ The `chef-client` recipe will create the chef-client service configured under da
 On Mac OS X and Mac OS X Server, the default service implementation is "launchd". Launchd support for the service resource is only supported from Chef 0.10.10 onwards.
 An error message will be logged if you try to use the launchd service for chef-client on a Chef version that does not contain this launchd support.
 
-Since launchd can run a service in interval mode, chef-client is not started in daemon mode like on Debian or Ubuntu. Keep this in mind when you look at your process list and check for a running chef process!
+Since launchd can run a service in interval mode, by default chef-client is not started in daemon mode like on Debian or Ubuntu. Keep this in mind when you look at your process list and check for a running chef process! If you wish to run chef-client in daemon mode, set attribute `chef_client.launchd_mode` to "daemon".
 
 Templates
 =========

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,11 @@ when "mac_os_x","mac_os_x_server"
   default["chef_client"]["run_path"]    = nil
   default["chef_client"]["cache_path"]  = "/Library/Caches/Chef"
   default["chef_client"]["backup_path"] = "/Library/Caches/Chef/Backup"
+  # Set to "daemon" if you want chef-client to run
+  # continuously with the -d and -s options, or leave
+  # as "interval" if you want chef-client to be run
+  # periodically by launchd
+  default["chef_client"]["launchd_mode"] = "interval"
 when "openindiana","opensolaris","nexentacore","solaris2"
   default["chef_client"]["init_style"]  = "smf"
   default["chef_client"]["run_path"]    = "/var/run/chef"

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -246,6 +246,9 @@ when "launchd"
     template "/Library/LaunchDaemons/com.opscode.chef-client.plist" do
       source "com.opscode.chef-client.plist.erb"
       mode 0644
+      variables(
+        :launchd_mode => node["chef_client"]["launchd_mode"]
+      )
     end
 
     service "chef-client" do

--- a/templates/default/com.opscode.chef-client.plist.erb
+++ b/templates/default/com.opscode.chef-client.plist.erb
@@ -5,14 +5,25 @@
 <dict>
   <key>Label</key>
   <string>com.opscode.chef-client</string>
+<%- if @launchd_mode == "interval" %>
   <key>Program</key>
   <string>/usr/bin/chef-client</string>
   <key>StartInterval</key>
   <integer><%= node["chef_client"]["interval"] %></integer>
   <key>RunAtLoad</key>
   <true/>
+<%- else %>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/chef-client</string>
+    <string>-i <%= node["chef_client"]["interval"] %></string>
+    <string>-s <%= node["chef_client"]["splay"] %></string>
+  </array>
+<%- end %>
   <key>UserName</key>
   <string>root</string>
+  <key>StandardOutPath</key>
+  <string><%= node["chef_client"]["log_dir"] %>/client.log</string>
 </dict>
 
 </plist>


### PR DESCRIPTION
Service recipe extended to register chef-client as a Launchd service via the new macosx service provider in Chef >=0.10.10
