### PR TITLE
[COOK-1506] Prefer node attribute over configuration value.

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -1,10 +1,10 @@
 log_level        :info
 log_location     STDOUT
 
-<% if Chef::Config.has_key?(:chef_server_url) -%>
-chef_server_url  "<%= Chef::Config[:chef_server_url] %>"
-<% else -%>
+<% if node.attribute?("chef_client") && node["chef_client"]["server_url"] -%>
 chef_server_url  "<%= node["chef_client"]["server_url"] %>"
+<% else -%>
+chef_server_url  "<%= Chef::Config[:chef_server_url] %>"
 <% end -%>
 validation_client_name "<%= node["chef_client"]["validation_client_name"] %>"
 <% if @chef_node_name -%>


### PR DESCRIPTION
Since Chef sets a default for the chef_server_url configuration value
the Chef::Config object will almost always have a key even if we
didn't intend it to.
