### PR TITLE
Removed random splay for unique sleep number

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -3,7 +3,7 @@
 # Author:: Seth Chisamore (<schisamo@opscode.com>)
 # Author:: Bryan Berry (<bryan.berry@gmail.com>)
 # Cookbook Name:: chef-client
-# Recipe:: cron 
+# Recipe:: cron
 #
 # Copyright 2009-2011, Opscode, Inc.
 #
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+require "digest/md5"
 
 root_group = value_for_platform(
                                 ["openbsd", "freebsd", "mac_os_x"] => { "default" => "wheel" },
@@ -73,12 +75,15 @@ service "chef-client" do
 end
 
 cron "chef-client" do
-  minute node['chef_client']['cron']['minute']	
-  hour	node['chef_client']['cron']['hour']
-  path node['chef_client']['cron']['path'] if node['chef_client']['cron']['path']
-  user	"root"
-  shell	"/bin/bash"
-  command "/bin/sleep `/usr/bin/expr $RANDOM \\% 90` &> /dev/null ; #{client_bin} &> /dev/null "
+  minute  node['chef_client']['cron']['minute']
+  hour    node['chef_client']['cron']['hour']
+  path    node['chef_client']['cron']['path'] if node['chef_client']['cron']['path']
+  user    "root"
+  shell   "/bin/bash"
+
+  # Generate a uniformly distributed unique number to sleep.
+  checksum = Digest::MD5.hexdigest node['fqdn']
+  sleep_time = checksum.to_s.hex % 90
+
+  command "/bin/sleep #{sleep_time}; #{client_bin} &> /dev/null"
 end
-
-


### PR DESCRIPTION
In an effort to better deal with random sleep collisions, generating a sleep
time based off the nodes hostname.  This sleep time will not change so long
as the hostname remains the same.

http://www.stdlib.net/~colmmacc/2009/09/14/period-pain/

Generated 5k hostnames based off the scheme c#r#.example.com.
Where c1 (c1-c1000) and r1 (r1-r5)

Generated sleep times from the hostname list mentioned above, and encountered
collisions of ~2%.  This seems reasonable, and wouldn't expect it to be worse
than what was previously used.
