### PR TITLE
COOK-1755 Explicitly control delete_validation recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default["chef_client"]["validation_client_name"] = "chef-validator"
 default["chef_client"]["cron"] = { "minute" => "0", "hour" => "*/4", "path" => nil}
 default["chef_client"]["environment"] = nil
 default["chef_client"]["load_gems"] = {}
+default["chef_client"]["delete_validation"] = true
 
 case platform
 when "arch"

--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-unless node['recipes'].include?("chef-server")
+if node['chef_client']['delete_validation']
   file Chef::Config[:validation_key] do
     action :delete
     backup false


### PR DESCRIPTION
The current code disables delete_validation if chef-server is included in node['recipes'] but
what if a chef-server isn't being managed by the chef-server cookbook?

Using a delete_validation attribute lets you include chef-client::disable_validation in a
base recipe for _all_ systems while retaining explicit control to disable the deletion as necessary.
