### PR TITLE
[COOK-1664] Adds permissions handling to cron recipe

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -44,9 +44,16 @@ end
 %w{run_path cache_path backup_path log_dir}.each do |key|
   directory node["chef_client"][key] do
     recursive true
-    owner "root"
-    group root_group
     mode 0755
+    unless node["platform"] == "windows"
+      if node.recipe?("chef-server")
+        owner "chef"
+        group "chef"
+      else
+        owner "root"
+        group root_group
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This follows the behavior of COOK-599, COOK-985 in setting the correct
permissions of the directories based on whether the system is also a chef-server.

Ref: http://tickets.opscode.com/browse/COOK-1664
