### PR TITLE
[COOK-2052] Set mode for node['chef_client']['log_dir'] to 00640

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -59,6 +59,10 @@ log_path = case node["chef_client"]["log_file"]
   end
 end
 
+file log_path do
+  mode 00640
+end
+
 chef_requires = []
 node["chef_client"]["load_gems"].each do |gem_name, gem_info_hash|
   gem_info_hash ||= {}


### PR DESCRIPTION
This fixes the directory, but not the file (which isn't managed by the cookbook).
