### PR TITLE
Typo: the chef-client executable has a hyphen

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -34,7 +34,7 @@ if ::File.executable?(node["chef_client"]["bin"])
 elsif Chef::Client.const_defined?('SANE_PATHS') && (chef_in_sane_path=Chef::Client::SANE_PATHS.map{|p| p="#{p}/chef-client";p if ::File.executable?(p)}.compact.first) && chef_in_sane_path
   client_bin = chef_in_sane_path
   # last ditch search for a bin in PATH
-elsif (chef_in_path=%x{which chef_client}.chomp) && ::File.executable?(chef_in_path)
+elsif (chef_in_path=%x{which chef-client}.chomp) && ::File.executable?(chef_in_path)
   client_bin = chef_in_path
 else
   raise "Could not locate the chef-client bin in any known path. Please set the proper path by overriding node['chef_client']['bin'] in a role."


### PR DESCRIPTION
This is just a small typo fix in the cron cookbook. The `chef-client` executable is not called `chef_client`.
