### PR TITLE
Fixed deprecation warnings for use of Chef::Mixin::Language

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,7 +20,7 @@
 module Opscode
   module ChefClient
     module Helpers
-      include Chef::Mixin::Language
+      include Chef::DSL::PlatformIntrospection
 
       def chef_server?
         node.recipe?("chef-server") || system("which chef-server")


### PR DESCRIPTION
During a chef-client run using chef-client::delete_validation results in the following warning under chef 11.x:

```
[2013-02-14T20:27:58+00:00] WARN: Chef::Mixin::Language is deprecated. Use either (or both)
Chef::DSL::PlatformIntrospection or Chef::DSL::DataQuery instead.

[2013-02-14T20:27:58+00:00] WARN: Called from: 
    /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-client/libraries/helpers.rb:23:in `<module:Helpers>'
    /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-client/libraries/helpers.rb:22:in `<module:ChefClient>'
    /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-client/libraries/helpers.rb:21:in `<module:Opscode>'
```

Changed Chef::Mixin::Language to Chef::DSL::PlatformIntrospection
