### PR TITLE
Fixed deprecation warnings for use of Chef::Mixin::Language

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,14 +20,18 @@
 module Opscode
   module ChefClient
     module Helpers
-      include Chef::Mixin::Language
+      if Chef::VERSION >= '11.0.0'
+        include Chef::DSL::PlatformIntrospection
+      else
+        include Chef::Mixin::Language
+      end
 
       def chef_server?
-				if node["platform"] == "windows"
-					node.recipe?("chef-server")
-				else
-					node.recipe?("chef-server") || system("which chef-server &> /dev/null ") || system("which chef-server-ctl &> /dev/null")
-				end
+        if node["platform"] == "windows"
+          node.recipe?("chef-server")
+        else
+          node.recipe?("chef-server") || system("which chef-server &> /dev/null ") || system("which chef-server-ctl &> /dev/null")
+        end
       end
 
       def create_directories


### PR DESCRIPTION
During a chef-client run using chef-client::delete_validation results in the following warning under chef 11.x:

```
[2013-02-14T20:27:58+00:00] WARN: Chef::Mixin::Language is deprecated. Use either (or both)
Chef::DSL::PlatformIntrospection or Chef::DSL::DataQuery instead.

[2013-02-14T20:27:58+00:00] WARN: Called from:
    /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-client/libraries/helpers.rb:23:in `<module:Helpers>'
    /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-client/libraries/helpers.rb:22:in `<module:ChefClient>'
    /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chef-client/libraries/helpers.rb:21:in `<module:Opscode>'
```

Changed Chef::Mixin::Language to Chef::DSL::PlatformIntrospection when running Chef >= 11.0.0.

In addition, fixed some minor formatting issues where real tabs were used instead of spaces.
