### PR TITLE
[COOK-2464] Recipe fails if shf-server didn't create 'chef' user yet.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -42,7 +42,7 @@ module Opscode
             else
               mode 00755
             end
-            if server
+            if server && node["etc"]["passwd"]["chef"]
               owner "chef"
               group "chef"
             else


### PR DESCRIPTION
If chef-client recipe goes prior than chef-server recipe and user 'chef' is not created yet than whole run fails.
