### PR TITLE
[COOK-2504] Chef-client::cron minitest fails when chef-client is at /usr/local/bin/chef-client

### DIFF
--- a/files/default/tests/minitest/cron_test.rb
+++ b/files/default/tests/minitest/cron_test.rb
@@ -24,6 +24,6 @@ describe 'chef-client::cron' do
 
   it 'creates the cron command' do
     cron("chef-client").command.
-      must_match %r{/bin/sleep \d+;  /usr/bin/chef-client &> /dev/null}
+      must_match %r{/bin/sleep \d+;  /usr/.*bin/chef-client &> /dev/null}
   end
 end


### PR DESCRIPTION
Change cron test regex to allow /usr/local/bin/chef-client as possible command in cron command.
