### PR TITLE
[COOK-2536] Set the group ownership correctly in BSD

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -51,7 +51,7 @@ module Opscode
                 "default" => "root"
               )
               group value_for_platform_family(
-                ["openbsd", "freebsd", "mac_os_x"] => [ "wheel" ],
+                ["openbsd", "freebsd", "mac_os_x"] => "wheel",
                 "default" => "root"
               )
             end


### PR DESCRIPTION
Details in the jira story - COOK-2536.

Tested this on freebsd 9.1
