### PR TITLE
[COOK-2731] Add attributes for the chef-server user and group, they stil...

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Attributes
 * `node["chef_client"]["checksum_cache_path"]` -  file system path used in the `cache_options` section of the client.rb file.
 * `node["chef_client"]["launchd_mode"]` - (Only for Mac OS X) if set to "daemon", runs chef-client with `-d` and `-s` options; defaults to "interval"
 * `node["chef_client"]["daemon_options"]` - An array of additional options to pass to the chef-client service, empty by default, and must be an array if specified.
+* `node["chef_client"]["chef_server_user"]` - The user that chef-server is installed under if running on the same node as a chef-server, defaults to 'chef'.
+* `node["chef_client"]["chef_server_group"]` - The group that chef-server is installed under if running on the same node as a chef-server, defaults to 'chef'.
 * `node["ohai"]["disabled_plugins"]` - An array of ohai plugins to disable, empty by default, and must be an array if specified.
 
 Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,8 @@ default["chef_client"]["report_handlers"] = []
 default["chef_client"]["exception_handlers"] = []
 default["chef_client"]["checksum_cache_skip_expires"] = true
 default["chef_client"]["daemon_options"] = []
+default["chef_client"]["chef_server_user"] = "chef"
+default["chef_client"]["chef_server_group"] = "chef"
 default["ohai"]["disabled_plugins"] = [] #Sets disabled_plugins to empty array
 
 case node['platform_family']

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -52,8 +52,8 @@ module Opscode
               mode 00755
             end
             if server
-              owner "chef"
-              group "chef"
+              owner node["chef_client"]["chef_server_user"]
+              group node["chef_client"]["chef_server_group"]
             else
               owner value_for_platform(
                 ["windows"] => { "default" => "Administrator" },


### PR DESCRIPTION
...l default to 'chef' as before, but now can be overwritten via attributes to work with Chef Server 11.
