### PR TITLE
[COOK-2607] Handle exception when run on a Chef 11 server

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -52,8 +52,13 @@ module Opscode
               mode 00755
             end
             if server
-              owner "chef"
-              group "chef"
+              begin
+                Etc.getpwnam("chef")
+                owner "chef"
+                group "chef"
+              rescue ArgumentError => e
+                Chef::Log.debug("chef user does not exist")
+              end
             else
               owner value_for_platform(
                 ["windows"] => { "default" => "Administrator" },


### PR DESCRIPTION
The current 'chef-server' cookbook that installs Erchef (Chef Server
version 11) does not create a 'chef' user.

http://tickets.opscode.com/browse/COOK-2607
