### PR TITLE
[COOK-2825] SMF does not rely on method script for stop/refresh

### DIFF
--- a/templates/default/solaris/chef-client.erb
+++ b/templates/default/solaris/chef-client.erb
@@ -56,21 +56,8 @@ case "$1" in
 $DAEMON $DAEMON_OPTS
 ;;
 
-'stop')
-kill `cat $PIDFILE`
-;;
-
-'refresh')
-kill -1 `cat $PIDFILE`
-;;
-
-'restart')
-kill `cat $PIDFILE`
-$DAEMON $DAEMON_OPTS
-;;
-
 *)
-echo $"Usage: $0 (start|stop|restart|refresh)"
+echo $"Usage: $0 (start)"
 exit 1
 ;;
 

--- a/templates/default/solaris/manifest.xml.erb
+++ b/templates/default/solaris/manifest.xml.erb
@@ -64,21 +64,14 @@
         <exec_method
                 type='method'
                 name='stop'
-                exec='<%= node['chef_client']['method_dir'] %>/chef-client %m'
+                exec=':kill'
                 timeout_seconds='60'>
         </exec_method>
         
         <exec_method
                 type='method'
                 name='refresh'
-                exec='<%= node['chef_client']['method_dir'] %>/chef-client %m'
-                timeout_seconds='60'>
-        </exec_method>
-        
-        <exec_method
-                type='method'
-                name='restart'
-                exec='<%= node['chef_client']['method_dir'] %>/chef-client %m'
+                exec=':kill -1'
                 timeout_seconds='60'>
         </exec_method>
         


### PR DESCRIPTION
- Service management through PID files is very error prone. SMF managed
  PID contracts for us, so we can use :kill [-SIGNAL] to stop
  or refresh the service.
- 'svcadm restart' will automatically call stop, then start if it is not
  defined to be something different in the manifest. We are removing the
  'restart' method for this reason.
