### PR TITLE
Make the chef-client service start delayed-auto on Windows.

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -259,6 +259,12 @@ when "winsw"
   execute "Install chef-client service using winsw" do
     command "#{winsw_path} install"
     only_if { WMI::Win32_Service.find(:first, :conditions => {:name => "chef-client"}).nil? }
+    notifies :run, "execute[set chef-client to delayed start]", :immediately
+  end
+
+  execute "set chef-client to delayed start" do
+    command "sc config chef-client start= delayed-auto"
+    action :nothing
   end
 
   service "chef-client" do


### PR DESCRIPTION
The Chef Client service fails to start on-boot on Windows Server 2008 & 2012, with the following events logged:

"A timeout was reached (30000 milliseconds) while waiting for the Chef-client Service for Windows service to connect."

"The Chef-client Service for Windows service failed to start due to the following error: 
The service did not respond to the start or control request in a timely fashion."

Setting the service startup type to Automatic (delayed start) fixes it.
