### PR TITLE
[COOK-2607] Handle exception when run on a Chef 11 server

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,8 +50,6 @@ module Opscode
       def create_directories
         return if node["platform"] == "windows"
 
-        Chef::Log.debug("Chef Server? #{server}")
-
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |key|
           directory node["chef_client"][key] do
             recursive true


### PR DESCRIPTION
Refactor https://github.com/opscode-cookbooks/chef-client/pull/89 by:
- encapsulating check for when `chef_user_exists?`
- extract `root_user` & `root_group` 
- unifying the code paths for selecting user & group so the default user and group aren't implicitly used on a machine which has `chef-server` installed but has no `chef` user.
