### PR TITLE
[ COOK-3123] Configure start_handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Attributes
 * `node["chef_client"]["cron"]["log_file"]` - Location to capture the chef-client output.
 * `node["chef_client"]["cron"]["use_cron_d"]` - If true, use the "cron_d" LWRP (https://github.com/opscode-cookbooks/cron). If false (default), use the cron resource built-in to Chef.
 * `node["chef_client"]["load_gems"]` - Hash of gems to load into chef via the client.rb file
+* `node["chef_client"]["start_handlers"]` - Array of Hashes that contain a class and arguments element appended in the client.rb file. ex: `{:class => "MyHandler", :arguments => [true]}
 * `node["chef_client"]["report_handlers"]` - Array of Hashes that contain a class and arguments element appended in the client.rb file. ex: `{:class => "MyHandler", :arguments => [true]}
 * `node["chef_client"]["exception_handlers"]` - Array of Hashes that contain a class and arguments element appended in the client.rb file. ex: `{:class => "MyHandler", :arguments => [true]}
 * `node["chef_client"]["checksum_cache_skip_expires"]` - true or false value used in the `cache_options` section of the client.rb file.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,7 @@ default["chef_client"]["environment"] = nil
 default["chef_client"]["load_gems"] = {}
 default["chef_client"]["report_handlers"] = []
 default["chef_client"]["exception_handlers"] = []
+default["chef_client"]["start_handlers"] = []
 default["chef_client"]["checksum_cache_skip_expires"] = true
 default["chef_client"]["daemon_options"] = []
 default["ohai"]["disabled_plugins"] = [] #Sets disabled_plugins to empty array

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -76,6 +76,7 @@ template "#{node["chef_client"]["conf_dir"]}/client.rb" do
     :chef_environment => node["chef_client"]["environment"],
     :chef_requires => chef_requires,
     :chef_verbose_logging => node["chef_client"]["verbose_logging"],
+    :chef_start_handlers => node["chef_client"]["start_handlers"],
     :chef_report_handlers => node["chef_client"]["report_handlers"],
     :chef_exception_handlers => node["chef_client"]["exception_handlers"],
     :ohai_disabled_plugins => ohai_disabled_plugins

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -53,7 +53,13 @@ Ohai::Config[:disabled_plugins] =  <%= @ohai_disabled_plugins %>
 
 <% if @chef_environment %>
 environment "<%= @chef_environment %>"
-<% end %>  
+<% end %>
+
+<% unless @chef_start_handlers.empty? %>
+  <% @chef_start_handlers.each do |handler| %>
+    start_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
+  <% end %>
+<% end %>
 
 <% unless @chef_report_handlers.empty? %>
   <% @chef_report_handlers.each do |handler| %>


### PR DESCRIPTION
This patch allow the chef-client cookbook to configure a set of start handlers which are specified in chef-client attributes 
