### PR TITLE
[COOK-3104] Fixes issues with attributes set in cook-2086 tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -108,7 +108,8 @@ suites:
   - recipe[chef-client::cron]
   attributes:
     chef_client:
-      environment_variables: "FOO=BAR"
+      cron:
+        environment_variables: "FOO=BAR"
 
 # No longer necessary w/ COOK-2856
 # - name: cook-2317

--- a/files/default/tests/minitest/cron_test.rb
+++ b/files/default/tests/minitest/cron_test.rb
@@ -24,6 +24,6 @@ describe 'chef-client::cron' do
 
   it 'creates the cron command' do
     cron("chef-client").command.
-      must_match %r{/bin/sleep \d+;  /usr/bin/chef-client &> /dev/null}
+      must_match %r{/bin/sleep \d+;.*/usr/bin/chef-client &> /dev/null}
   end
 end


### PR DESCRIPTION
Set the environment_variable correctly for 2086 and fix issue with minitest that fails with that string set properly in the cronjob.
