### PR TITLE
[COOK-3104] Added or whitespace to regex in cron_test.rb

### DIFF
--- a/files/default/tests/minitest/cron_test.rb
+++ b/files/default/tests/minitest/cron_test.rb
@@ -24,6 +24,6 @@ describe 'chef-client::cron' do
 
   it 'creates the cron command' do
     cron("chef-client").command.
-      must_match %r{/bin/sleep \d+; ([A-Za-z]+=.*) /usr/bin/chef-client &> /dev/null}
+      must_match %r{/bin/sleep \d+; ([A-Za-z]+=.*)|[\s] /usr/bin/chef-client &> /dev/null}
   end
 end


### PR DESCRIPTION
This is a fix for this failure,

```
7 tests, 8 assertions, 1 failures, 0 errors, 0 skips       
       [2013-06-24T14:25:10+00:00] INFO: Report handlers complete
       [2013-06-24T14:25:10+00:00] ERROR: Running exception handlers
       [2013-06-24T14:25:10+00:00] ERROR: Exception handlers complete
Chef Client failed. 15 resources updated       
       [2013-06-24T14:25:10+00:00] FATAL: Stacktrace dumped to /tmp/kitchen-chef-solo/cache/chef-stacktrace.out
       [2013-06-24T14:25:10+00:00] FATAL: RuntimeError: MiniTest failed with 1 failure(s) and 0 error(s).
       Failure:
       chef-client::cron#test_0002_creates the cron command [/var/chef/minitest/chef-client/cron_test.rb:26]:
       Expected /\/bin\/sleep \d+; ([A-Za-z]+=.*) \/usr\/bin\/chef-client &> \/dev\/null/ to match "/bin/sleep 150;  /usr/bin/chef-client &> /dev/null".

>>>>>> Converge failed on instance <cook-2169-root-ubuntu-1204>.
>>>>>> Please see .kitchen/logs/cook-2169-root-ubuntu-1204.log for more details
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: SSH exited (1) for command: [sudo chef-solo -c /tmp/kitchen-chef-solo/solo.rb -j /tmp/kitchen-chef-solo/dna.json --log_level info]
>>>>>> ----------------------
```
