### PR TITLE
[COOK-3466] Reduce warnings about duplicate resources 

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -70,17 +70,21 @@ module Opscode
       end
 
       def create_directories
+        return if node.run_state["chef-client/create_directories"]
+
         # dir_owner and dir_group are not found in the block below.
         d_owner = dir_owner
         d_group = dir_group
         %w{run_path cache_path backup_path log_dir conf_dir}.each do |dir|
-          directory node["chef_client"][dir] do
+            directory node["chef_client"][dir] do
             recursive true
             mode 00750 if dir == "log_dir"
             owner d_owner
             group d_group
           end
         end
+
+        node.run_state["chef-client/create_directories"] = true
       end
 
       def find_chef_client


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3466

The chef-client cookbook puts out a lot of warnings about duplicated resources, because it invokes a helper-method in multiple places.
This just puts a variable in node.run_state, so the helper-method will only take effect once.
