### PR TITLE
[COOK-3492] Add tests for upstart on CentOS 6.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -71,7 +71,7 @@ suites:
   - recipe[minitest-handler]
   - recipe[chef-client_test::service_upstart]
   - recipe[chef-client::upstart_service]
-  excludes: ["centos-5.9", "centos-6.4"]
+  excludes: ["centos-5.9"]
   attributes: {}
 
 - name: cron

--- a/files/default/tests/minitest/service_test.rb
+++ b/files/default/tests/minitest/service_test.rb
@@ -19,6 +19,9 @@ require File.expand_path('../support/helpers', __FILE__)
 describe 'chef-client::service' do
   include Helpers::ChefClient
   it "starts the chef-client service" do
-    service("chef-client").must_be_running
+    r = Chef::Resource::Service.new("chef-client", @run_context)
+    r.provider Chef::Provider::Service::Upstart
+    current_resource = r.provider_for_action(:start).load_current_resource
+    current_resource.running.must_equal true
   end
 end

--- a/test/cookbooks/chef-client_test/files/default/tests/minitest/service_upstart_test.rb
+++ b/test/cookbooks/chef-client_test/files/default/tests/minitest/service_upstart_test.rb
@@ -22,7 +22,10 @@ require File.expand_path('../support/helpers', __FILE__)
 describe 'chef-client::config' do
   include Helpers::ChefClient
   it 'enables and starts the upstart service' do
-    service('chef-client').must_be_running
+    r = Chef::Resource::Service.new("chef-client", @run_context)
+    r.provider Chef::Provider::Service::Upstart
+    current_resource = r.provider_for_action(:start).load_current_resource
+    current_resource.running.must_equal true
     file('/etc/init/chef-client.conf').must_exist
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3492

Because of how the minitest handler for Chef works, we've had to
resort to the uglier test construction used here.  Alternatively, we
could have inspected the state of the system directly.

For more information on the issue in minitest, see:

https://github.com/calavera/minitest-chef-handler/issues/66
