### PR TITLE
[COOK-3827] Create a scheduled task to rotate logs on Windows

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,9 @@ default["chef_client"]["cron"] = {
   "use_cron_d" => false
 }
 
+default["chef_client"]["task"]["user"] = 'SYSTEM'
+default["chef_client"]["task"]["password"] = '' # SYSTEM user does not need a password, but windows_task LWRP wants one
+
 default["chef_client"]["load_gems"] = {}
 
 # Any additional daemon options can be set as an array. This will be

--- a/templates/windows/logrotate.rb.erb
+++ b/templates/windows/logrotate.rb.erb
@@ -1,0 +1,2 @@
+require 'logrotate'
+LogRotate.rotate_file('<%= @log_path %>', count: <%= @count %>, gzip: true)


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3827

Uuses the [logrotate](http://rubyforge.org/projects/logrotate) gem and a windows scheduled task to create a log rotate task that works similar to how logrotate.d works in linux.
