### PR TITLE
[COOK-4038] Don't define CHEF_SERVER_USER constant if already defined

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,12 +20,11 @@
 module Opscode
   module ChefClient
     module Helpers
-      if Chef::VERSION >= '11.0.0'
-        include Chef::DSL::PlatformIntrospection
-        CHEF_SERVER_USER = 'chef_server'
-      else
-        include Chef::Mixin::Language
-        CHEF_SERVER_USER = 'chef'
+      include Chef::Mixin::Language if Chef::VERSION < '11.0.0'
+      include Chef::DSL::PlatformIntrospection if Chef::VERSION >= '11.0.0'
+
+      def chef_server_user
+        Chef::VERSION >= '11.0.0' ? 'chef_server' : 'chef'
       end
 
       def chef_server?
@@ -45,7 +44,7 @@ module Opscode
 
       def dir_owner
         if chef_server?
-          CHEF_SERVER_USER
+          chef_server_user
         else
           root_owner
         end
@@ -63,7 +62,7 @@ module Opscode
 
       def dir_group
         if chef_server?
-          CHEF_SERVER_USER
+          chef_server_user
         else
           root_group
         end

--- a/test/cookbooks/chef-client_test/recipes/cook-2169-chef.rb
+++ b/test/cookbooks/chef-client_test/recipes/cook-2169-chef.rb
@@ -22,7 +22,7 @@ class Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-user CHEF_SERVER_USER do
+user chef_server_user do
   action :nothing
 end.run_action(:create)
 


### PR DESCRIPTION
This solves issues with Chefspec where chef-client gets loaded repeatedly:

```
chef-client/libraries/helpers.rb:25: warning: already initialized constant Opscode::ChefClient::Helpers::CHEF_SERVER_USER
```

Another possibility would be to forgo the use of constants.
