### PR TITLE
[COOK-4092] Add KeepAlive so that launchd will "daemonize" chef-client for us.

### DIFF
--- a/templates/default/com.opscode.chef-client.plist.erb
+++ b/templates/default/com.opscode.chef-client.plist.erb
@@ -22,9 +22,9 @@
     <string><%= option %></string>
     <% end -%>
   </array>
+  <key>KeepAlive</key>
+  <true/>
 <%- end %>
-  <key>UserName</key>
-  <string>root</string>
   <key>StandardOutPath</key>
   <string><%= node["chef_client"]["log_dir"] %>/client.log</string>
 </dict>


### PR DESCRIPTION
Also remove unnecessary UserName parameter. launchd runs as root so we're good.
