### PR TITLE
COOK-4169 adding the "options" parameter as optional attribute

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -60,6 +60,7 @@ node['chef_client']['load_gems'].each do |gem_name, gem_info_hash|
   chef_gem gem_name do
     action gem_info_hash[:action] || :install
     version gem_info_hash[:version] if gem_info_hash[:version]
+    options ( gem_info_hash[:options] ) if gem_info_hash[:options]
   end
   chef_requires.push(gem_info_hash[:require_name] || gem_name)
 end


### PR DESCRIPTION
COOK-4169 adding the "options" parameter as optional attribute to the optional gems install procedure.

this makes it possible to define a proxy server or local repository for installations that do not have a open internet connection. 
