### PR TITLE
add cron support for fedora 19

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -34,7 +34,8 @@ create_directories
 
 dist_dir, conf_dir = value_for_platform_family(
   ['debian'] => %w{ debian default },
-  ['rhel'] => %w{ redhat sysconfig }
+  ['rhel'] => %w{ redhat sysconfig },
+  ['fedora'] => %w{ redhat sysconfig }
   )
 
 # let's create the service file so the :disable action doesn't fail


### PR DESCRIPTION
chef-client::cron does not support fedora 19 in the recipe. this might be due to fedora 19 not being classified as "rhel". In chef-client::cron, copying "rhel" and renaming it to "fedora" allows the cron recipe to work with Fedora 19.

```
Failed run output:
Cookbook 'chef-client' does not contain a file at any of these locations:
  templates/fedora-19//init.d/chef-client.erb
  templates/fedora//init.d/chef-client.erb
  templates/default//init.d/chef-client.erb

This cookbook _does_ contain: ['conf.d/chef-client.conf.erb','rc.d/chef-client.erb','chef-client.pill.erb','client.rb.erb','com.opscode.chef-client.plist.erb','debian/default/chef-client.erb','debian/init.d/chef-client.erb','debian/init/chef-client.conf.erb','redhat/init.d/chef-client.erb','redhat/sysconfig/chef-client.erb','solaris/chef-client.erb','solaris/manifest.xml.erb','suse/init.d/chef-client.erb','suse/sysconfig/chef-client.erb','sv-chef-client-log-run.erb','sv-chef-client-run.erb','chef-client.xml.erb']


Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/chef-client/recipes/cron.rb

 42:   template "/etc/init.d/chef-client" do
 43:     source "#{dist_dir}/init.d/chef-client.erb"
 44:     mode 0755
 45:     variables( :client_bin => client_bin )
 46:   end
 47: 



Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/chef-client/recipes/cron.rb:42:in `from_file'    

template("/etc/init.d/chef-client") do
  provider Chef::Provider::Template
  action "create"
  retries 0
  retry_delay 2
  path "/etc/init.d/chef-client"
  backup 5
  atomic_update true
  source "/init.d/chef-client.erb"
  variables {:client_bin=>"/usr/bin/chef-client"}
  cookbook_name "chef-client"
  recipe_name "cron"
  mode 493
end
```
