### PR TITLE
Fix syntax error in cron_test.rb

### DIFF
--- a/files/default/tests/minitest/cron_test.rb
+++ b/files/default/tests/minitest/cron_test.rb
@@ -30,7 +30,7 @@ describe 'chef-client::cron' do
     if node['chef_client']['cron']['use_cron_d']
       file('/etc/cron.d/chef-client').must_match %r{/bin/sleep \d+; (([A-Za-z]+=.*)?) /usr/bin/chef-client > /dev/null 2>&1}
     else
-      cron('chef-client').command
+      cron('chef-client').command\
         .must_match %r{/bin/sleep \d+; (([A-Za-z]+=.*)?)|[\s] /usr/bin/chef-client > /dev/null 2>&1}
     end
   end


### PR DESCRIPTION
Hi

My ruby complains about the syntax on that line, i'm unsure if this is only on my machine.

gert@lerky:chef-repo/cookbooks# knife cookbook test chef-client
checking chef-client
Running syntax check on chef-client
Validating ruby files
FATAL: Cookbook file files/default/tests/minitest/cron_test.rb has a ruby syntax error:
FATAL: /home/gert/workspace/checksec/chef-repo/.chef/../cookbooks/chef-client/files/default/tests/minitest/cron_test.rb:34: syntax error, unexpected '.', expecting kEND
FATAL:         .must_match %r{/bin/sleep \d+; ...
FATAL:          ^

Ruby version:
gert@lerky:chef-repo/cookbooks# /opt/chef/embedded/bin/ruby -v
ruby 1.9.3p286 (2012-10-12 revision 37165) [x86_64-linux]
