### PR TITLE
[COOK-4331] chef-client does not honor no_proxy in ENV

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -30,10 +30,15 @@ node_name <%= @chef_config['node_name'].inspect %>
 ENV['http_proxy'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
 ENV['HTTP_PROXY'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
 <% end -%>
+<% unless node["chef_client"]["config"]["https_proxy"].nil? -%>
+ENV['https_proxy'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
+ENV['HTTPS_PROXY'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
+<% end -%>
 <% unless node["chef_client"]["config"]["no_proxy"].nil? -%>
 ENV['no_proxy'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
 ENV['NO_PROXY'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
 <% end -%>
+
 <% if node.attribute?("ohai") && node["ohai"].attribute?("plugin_path") -%>
 
 Ohai::Config[:plugin_path] << "<%= node["ohai"]["plugin_path"] %>"


### PR DESCRIPTION
Commit a13d50be72a048fd05fd1d6642b8f3b9eadfcca5 [COOK-513] does not honor the no_proxy environment variable in the ENV[] part.
