### PR TITLE
[COOK-4338] chef-client Upstart job starts too early

### DIFF
--- a/templates/default/debian/init/chef-client.conf.erb
+++ b/templates/default/debian/init/chef-client.conf.erb
@@ -4,7 +4,7 @@
 
 description "Chef Client"
 
-start on net-device-up
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 respawn


### PR DESCRIPTION
Make sure local-filesystems are mounted, and that an interface other than `lo` is up.
