### PR TITLE
Chef-Client Cron Job run with --once

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -92,7 +92,7 @@ if node['chef_client']['cron']['use_cron_d']
     user    'root'
     cmd = ''
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
-    cmd << "#{env} #{client_bin} > #{log_file} 2>&1"
+    cmd << "#{env} #{client_bin} --once > #{log_file} 2>&1"
     command cmd
   end
 else
@@ -108,7 +108,7 @@ else
     user    'root'
     cmd = ''
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
-    cmd << "#{env} #{client_bin} > #{log_file} 2>&1"
+    cmd << "#{env} #{client_bin} --once > #{log_file} 2>&1"
     command cmd
   end
 end


### PR DESCRIPTION
Hello,

Cron Job schedule creates a chef-client process every time it gets executed. Ideally cron job should run 
chef-client only once.

Due to missing "--once" client instance ends up with multiple chef-client processes.

Added --once to cron chef-client command to this pull request.

Cheers,
V
