### PR TITLE
COOK-4594: 'Found chef-client in' log resource

### DIFF
--- a/recipes/arch_service.rb
+++ b/recipes/arch_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/bluepill_service.rb
+++ b/recipes/bluepill_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/bsd_service.rb
+++ b/recipes/bsd_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/daemontools_service.rb
+++ b/recipes/daemontools_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/launchd_service.rb
+++ b/recipes/launchd_service.rb
@@ -7,9 +7,7 @@ require 'chef/version_constraint'
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/runit_service.rb
+++ b/recipes/runit_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/smf_service.rb
+++ b/recipes/smf_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 

--- a/recipes/winsw_service.rb
+++ b/recipes/winsw_service.rb
@@ -5,9 +5,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-log "Found chef-client in #{client_bin}" do
-  level :debug
-end
+Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 


### PR DESCRIPTION
Using the log resource for the 'Found chef-client in...' debug message causes it
to be reported as executed on each chef-run which I don't believe is the intention
and is confusing as it makes it appear like a resource was changed.

This will still log it when run in debug mode but not as a resource.
