### PR TITLE
[COOK-4721] Update cron.rb to work properly for SUSE

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -35,7 +35,8 @@ create_directories
 dist_dir, conf_dir = value_for_platform_family(
   ['debian'] => %w{ debian default },
   ['rhel'] => %w{ redhat sysconfig },
-  ['fedora'] => %w{ redhat sysconfig }
+  ['fedora'] => %w{ redhat sysconfig },
+  ['suse'] => %w{ suse sysconfig }
   )
 
 # let's create the service file so the :disable action doesn't fail


### PR DESCRIPTION
The recipe was unable to locate the template

ERROR: template[/etc/init.d/chef-client](chef-client::cron line 44) had an error: Chef::Exceptions::FileNotFound: Cookbook 'chef-client' (3.5.0) does not contain a file at any of these locations:
  templates/suse-11.3//init.d/chef-client.erb
  templates/suse//init.d/chef-client.erb
  templates/default//init.d/chef-client.erb
