### PR TITLE
[COOK-4710] - remove test for client_fork in conf

### DIFF
--- a/test/cookbooks/chef-client_test/files/default/tests/minitest/config_test.rb
+++ b/test/cookbooks/chef-client_test/files/default/tests/minitest/config_test.rb
@@ -62,10 +62,4 @@ describe 'chef-client::config' do
     directory(File.join(node['chef_client']['conf_dir'], 'client.d')).must_exist
   end
 
-  it 'includes client_fork true in the config file' do
-    file(File.join(node['chef_client']['conf_dir'], "client.rb")).must_match(
-      '^client_fork true'
-    )
-  end
-
 end


### PR DESCRIPTION
According to the README, we support older versions of Chef with this cookbook, and attributes/default.rb switches based on whether the chef_client key exists in conf. I don't think that we actually want to declare that `client_fork true` exists in conf as a requirement that this passes tests, so this PR removes the test. 
