### PR TITLE
[COOK-4714] Make Test Kitchen work for Ubuntu platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,9 +8,9 @@ platforms:
   - name: centos-5.10
   - name: centos-6.5
   - name: fedora-19
-  - name: ubuntu-1004
-  - name: ubuntu-1204
-  - name: ubuntu-1310
+  - name: ubuntu-10.04
+  - name: ubuntu-12.04
+  - name: ubuntu-13.10
 
 suites:
 # This suite tests that the configuration is applied correctly (via attributes)


### PR DESCRIPTION
It seems that, at some point, the platform names changed as I was getting 404s when Test Kitchen was attempting to download boxes for VBox. This PR updates the platform names so that box downloads work again.
