### PR TITLE
[COOK-4720] Sort config hash

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -8,7 +8,7 @@
 end
 
 <% end -%>
-<% @chef_config.each_key do |option| -%>
+<% @chef_config.keys.sort.each do |option| -%>
   <% next if %w{ node_name exception_handlers report_handlers start_handlers }.include?(option) -%>
   <% case option -%>
   <% when 'log_level', 'ssl_verify_mode' -%>


### PR DESCRIPTION
We should render the same output every run. As it is now, the config file is changing order every run.
