### PR TITLE
Fix for sring division by number

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ end
 
 # By default, we don't have a log file, as we log to STDOUT
 default['chef_client']['log_file']    = nil
-default['chef_client']['interval']    = '1800'
+default['chef_client']['interval']    = 1800
 default['chef_client']['splay']       = '300'
 default['chef_client']['conf_dir']    = '/etc/chef'
 default['chef_client']['bin']         = '/usr/bin/chef-client'


### PR DESCRIPTION
Chef run was failing with default attributes, while adding chef-client::config to CentOS box.
