### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ v3.5.0 (2014-05-07)
 v3.4.0 (2014-04-09)
 -------------------
 - [COOK-4521] - support Ohai 7 syntax for disabling plugins
-- [COOK-4505] - kill -9 chef-client when stopping vis SMF
+- [COOK-4505] - kill -9 chef-client when stopping via SMF
 
 
 v3.3.8 (2014-03-18)


### PR DESCRIPTION
typo fix, i think it should be 'via' as 'a' and 's' are close on keyboard, other possibilities could be 'with' as very direct typing of what you hear, however unlikely
