### PR TITLE
Fix FC007:  Ensure recipe dependencies are reflected

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,9 +23,14 @@ recipe 'chef-client::winsw_service', 'Configures chef-client as a service under 
   supports os
 end
 
+# Each of these suggested cookbooks are dependencies when using the
+# respective $SERVICE_MANAGER_service recipe.
+# Foodcritic comments are included in each recipe to ignore
+#   FC007: Ensure recipe dependencies are reflected in cookbook metadata
 suggests 'bluepill'
 suggests 'daemontools'
 suggests 'runit'
+
 depends 'cron', '>= 1.2.0'
 depends 'logrotate', '>= 1.2.0'
 depends 'windows', '~> 1.11'

--- a/recipes/bluepill_service.rb
+++ b/recipes/bluepill_service.rb
@@ -18,7 +18,7 @@ directory node['chef_client']['run_path'] do
   mode 0755
 end
 
-include_recipe 'bluepill'
+include_recipe 'bluepill' # ~FC007: bluepill is only required when using the bluepill_service recipe 
 
 template "#{node['bluepill']['conf_dir']}/chef-client.pill" do
   source 'chef-client.pill.erb'

--- a/recipes/daemontools_service.rb
+++ b/recipes/daemontools_service.rb
@@ -11,7 +11,7 @@ create_directories
 
 group = root_group
 
-include_recipe 'daemontools'
+include_recipe 'daemontools' # ~FC007: daemontools is only required when using the daemontools_service recipe 
 
 directory '/etc/sv/chef-client' do
   recursive true

--- a/recipes/runit_service.rb
+++ b/recipes/runit_service.rb
@@ -9,5 +9,5 @@ Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 
-include_recipe 'runit'
+include_recipe 'runit'  # ~FC007: runit is only required when using the runit_service recipe 
 runit_service 'chef-client'


### PR DESCRIPTION
Fix FC007:  Ensure recipe dependencies are reflected in cookbook metadata

Each of these suggested cookbooks are dependencies when using the
respective $SERVICE_MANAGER_service recipe.
Foodcritic comments are included in each recipe to ignore the rule.
