### PR TITLE
Fix the \xC3 on US-ASCII error reported by https://github.com/opscode-co...

### DIFF
--- a/templates/default/debian/init.d/chef-client.erb
+++ b/templates/default/debian/init.d/chef-client.erb
@@ -14,6 +14,9 @@
 # chkconfig: - 99 02
 # description: starts up chef-client in daemon mode.
 
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=<%= @client_bin %>
 NAME=chef-client


### PR DESCRIPTION
...okbooks/chef-client/issues/213

The issue I reported on
https://github.com/opscode-cookbooks/chef-client/issues/213

Was fixed by making this change to the init.d script.  I believe this is a problem with ruby 1.9.x that ships with Ubuntu 14.04 and older.  From what I read the issue goes away in ruby 2.0.  I also note that this is not the most graceful way to fix this problem, but it works.
