### PR TITLE
Fix FreeBSD service startup

### DIFF
--- a/templates/freebsd/chef-client.erb
+++ b/templates/freebsd/chef-client.erb
@@ -7,17 +7,9 @@
 . /etc/rc.subr
 
 name="chef"
-stop_cmd="chef_stop"
+pidfile="<%= node["chef_client"]["run_path"] %>/${name}.pid"
 command="<%= @client_bin %>"
 command_interpreter="<%= RbConfig.ruby %>"
-command_args="-i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -d -L <%= node["chef_client"]["log_dir"] %>/client.log  -P <%= node["chef_client"]["run_path"] %>/chef.pid"
+command_args="-i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -d -L <%= node["chef_client"]["log_dir"] %>/client.log -P <%= node["chef_client"]["run_path"] %>/${name}.pid"
 load_rc_config $name
-export rc_pid
-chef_stop()
-{
-  pidfile="<%= node["chef_client"]["run_path"] %>/chef.pid"
-  rc_pid=`cat ${pidfile}`
-        kill -9 $rc_pid
-}
-
 run_rc_command "$1"


### PR DESCRIPTION
Fixes #199 

The rc script committed in #143 has some problems; by not exporting `pidfile` at the top-level, it causes the FreeBSD service subsystem to dig around for a PID by using `/bin/ps`, which catches the currently-running Chef client run, thus causing the problem described in #199. By simplifying the rc script, this problem goes away.

Also, there is no need to define a special `chef_stop()` routine. We should just be relying on the service subsystem to do the right thing. Plus sending -9 to Chef is an unnecessarily large hammer; the service subsystem will send `TERM`.

/cc @cwebberOps 
