### PR TITLE
we have to source /etc/default/locale

### DIFF
--- a/templates/default/debian/init/chef-client.conf.erb
+++ b/templates/default/debian/init/chef-client.conf.erb
@@ -14,4 +14,10 @@ pre-start script
     test -x <%= @client_bin %> || { stop; exit 0; }
 end script
 
-exec <%= @client_bin %> -i <%= node["chef_client"]["interval"] %> -L <%= node["chef_client"]["log_dir"] %>/client.log <%= node["chef_client"]["daemon_options"].join(' ') %>
+script
+    if [ -r /etc/default/locale ]; then
+        . /etc/default/locale
+        export LANG LANGUAGE LC_MESSAGES LC_ALL
+    fi
+    exec <%= @client_bin %> -i <%= node["chef_client"]["interval"] %> -L <%= node["chef_client"]["log_dir"] %>/client.log <%= node["chef_client"]["daemon_options"].join(' ') %>
+end script


### PR DESCRIPTION
for unknown reasons, upstart doesn't do this.
