### PR TITLE
Fix missing NO_PROXY env var in client.rb

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -34,6 +34,10 @@ ENV['HTTP_PROXY'] = "<%= node["chef_client"]["config"]["http_proxy"] %>"
 ENV['https_proxy'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
 ENV['HTTPS_PROXY'] = "<%= node["chef_client"]["config"]["https_proxy"] %>"
 <% end -%>
+<% unless node["chef_client"]["config"]["no_proxy"].nil? -%>
+ENV['no_proxy'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
+ENV['NO_PROXY'] = "<%= node["chef_client"]["config"]["no_proxy"] %>"
+<% end -%>
 
 <% if node.attribute?("ohai") && node["ohai"].attribute?("plugin_path") -%>
 


### PR DESCRIPTION
This is related to https://github.com/opscode-cookbooks/chef-client/pull/148

While the no_proxy attribute is set in the client.rb the matching environment variable is not set. 
Additionally it appears the proxy options were largely untested so I added some tests
