### PR TITLE
Make the mode for the chef-client log an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The following attributes affect the behavior of the chef-client program when run
 * `node['chef_client']['log_dir']` - Sets directory used in
   `Chef::Config[:log_location]` via command-line option to a location
   where chef-client should log output. Default "/var/log/chef".
+  `node['chef_client']['log_file']` - Set the name of the chef-client log file.  Default `client.log`.
+  `node['chef_client]['log_file_mode']` - Set the mode of the chef-client log file.  Default `00640`.
 * `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.
 * `node['chef_client']['log_rotation']['prerotate']` - Set prerotate action for chef-client logrotation. Default to `nil`.
 * `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The following attributes affect the behavior of the chef-client program when run
 * `node['chef_client']['log_dir']` - Sets directory used in
   `Chef::Config[:log_location]` via command-line option to a location
   where chef-client should log output. Default "/var/log/chef".
-  `node['chef_client']['log_file']` - Set the name of the chef-client log file.  Default `client.log`.
-  `node['chef_client]['log_file_mode']` - Set the mode of the chef-client log file.  Default `00640`.
+* `node['chef_client']['log_file']` - Set the name of the chef-client log file.  Default `client.log`.
+* `node['chef_client]['log_file_mode']` - Set the mode of the chef-client log file.  Default `00640`.
 * `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.
 * `node['chef_client']['log_rotation']['prerotate']` - Set prerotate action for chef-client logrotation. Default to `nil`.
 * `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,7 @@ end
 
 # log_file has no effect when using runit
 default['chef_client']['log_file']    = 'client.log'
+default['chef_client']['log_file_mode'] = '00640'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
 default['chef_client']['conf_dir']    = '/etc/chef'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.3.0'
+version           '4.3.1'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::bluepill_service', 'Configures chef-client as a service under Bluepill'
 recipe 'chef-client::bsd_service', 'Configures chef-client as a service on *BSD'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -52,7 +52,7 @@ create_directories
 
 if log_path != 'STDOUT' #~FC023
   file log_path do
-    mode 00640
+    mode node['chef_client']['log_file_mode']
   end
 end
 


### PR DESCRIPTION
We need to make our chef-client log (/var/chef/log/client.log) readable by folks other than root.
I noticed that the mode for the log_file was hardcoded to '00640', which is good for security, but bad for our users without sudo access.

I have made the mode an attribute that can be overridden in a wrapper cookbook.
Optimistically, I have updated the docs to mention the new attribute and set the default to '00640' as well.

