### PR TITLE
fixes for freebsd cron invocation and kitchen changes required to test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,8 +3,6 @@ driver:
   customize:
     memory: 1024
     cpus: 2
-  ssh:
-    shell: '"/bin/sh"'
 
 provisioner:
   name: chef_zero
@@ -18,6 +16,9 @@ platforms:
   - name: fedora-21
   - name: freebsd-9.3
   - name: freebsd-10.1
+    driver:
+      ssh:
+        shell: '/bin/sh'
   - name: ubuntu-12.04
   - name: ubuntu-14.04
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,8 @@ driver:
   customize:
     memory: 1024
     cpus: 2
+  ssh:
+    shell: '"/bin/sh"'
 
 provisioner:
   name: chef_zero

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
   - 2.1
   - 2.2
 script:
-- rake spec
+- bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 cache: bundler
 language: ruby
-bundler_args: --without kitchen_common kitchen_vagrant kitchen_cloud
+bundler_args: --without kitchen_vagrant kitchen_cloud
 rvm:
   - 2.0
   - 2.1

--- a/Gemfile
+++ b/Gemfile
@@ -6,13 +6,13 @@ group :rake do
 end
 
 group :lint do
-  gem 'foodcritic', '~> 4.0'
+  gem 'foodcritic', '~> 5.0'
   gem 'rubocop', '~> 0.33'
 end
 
 group :unit do
   gem 'berkshelf',  '~> 3.2'
-  gem 'chefspec',   '~> 4.3'
+  gem 'chefspec',   '~> 4.4'
 end
 
 group :kitchen_common do
@@ -20,7 +20,7 @@ group :kitchen_common do
 end
 
 group :kitchen_vagrant do
-  gem 'kitchen-vagrant', '~> 0.18'
+  gem 'kitchen-vagrant', '~> 0.19'
 end
 
 group :kitchen_cloud do

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -41,18 +41,16 @@ dist_dir, conf_dir = value_for_platform_family(
 
 # let's create the service file so the :disable action doesn't fail
 case node['platform_family']
-when 'arch', 'debian', 'rhel', 'fedora', 'suse', 'openbsd', 'freebsd'
+when 'arch', 'debian', 'rhel', 'fedora', 'suse', 'openbsd'
   template '/etc/init.d/chef-client' do
     source "#{dist_dir}/init.d/chef-client.erb"
     mode 0755
     variables(client_bin: client_bin)
-    not_if { node['platform_family'] == 'freebsd'}
   end
 
   template "/etc/#{conf_dir}/chef-client" do
     source "#{dist_dir}/#{conf_dir}/chef-client.erb"
     mode 0644
-    not_if { node['platform_family'] == 'freebsd'}
   end
 
   service 'chef-client' do
@@ -67,6 +65,13 @@ when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'smartos', 'omnios
     action [:disable, :stop]
     provider Chef::Provider::Service::Solaris
     ignore_failure true
+  end
+
+when 'freebsd'
+  service 'chef-client' do
+    supports status: true, restart: true
+    provider Chef::Provider::Service::Upstart if node['chef_client']['init_style'] == 'upstart'
+    action [:disable, :stop]
   end
 end
 

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -46,11 +46,13 @@ when 'arch', 'debian', 'rhel', 'fedora', 'suse', 'openbsd', 'freebsd'
     source "#{dist_dir}/init.d/chef-client.erb"
     mode 0755
     variables(client_bin: client_bin)
+    not_if { node['platform_family'] == 'freebsd'}
   end
 
   template "/etc/#{conf_dir}/chef-client" do
     source "#{dist_dir}/#{conf_dir}/chef-client.erb"
     mode 0644
+    not_if { node['platform_family'] == 'freebsd'}
   end
 
   service 'chef-client' do


### PR DESCRIPTION
the cron recipe would not converge under freebsd, there's no init.d equiv and I thought the cleanest way would be to put a pair of not_if guards on the two unneeded templates. I also had to add the '"/bin/sh"' to the .kitchen.yml to get kitchen to work at all with the freebsd box files. I tested that the freebsd/cron suite works under vagrant and that my '"/bin/sh"' changes do not break at least the ubuntu suites.
