### PR TITLE
add windows service log location to client.service.rb and only pass to service manager for legacy clients

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,7 +31,7 @@ module Opscode
       end
 
       def chef_client_service_running
-        wmi_property_from_query(:name, "select * from Win32_Service where name = 'chef-client'") != nil
+        !wmi_property_from_query(:name, "select * from Win32_Service where name = 'chef-client'").nil?
       end
 
       def root_owner
@@ -48,7 +48,7 @@ module Opscode
         %w(run_path cache_path backup_path log_dir conf_dir).each do |dir|
           # Do not redefine the resource if it exist
           begin
-            r = resources(directory: node['chef_client'][dir])
+            resources(directory: node['chef_client'][dir])
           rescue Chef::Exceptions::ResourceNotFound
             directory node['chef_client'][dir] do
               recursive true

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -63,7 +63,7 @@ node['chef_client']['load_gems'].each do |gem_name, gem_info_hash|
     action gem_info_hash[:action] || :install
     source gem_info_hash[:source] if gem_info_hash[:source]
     version gem_info_hash[:version] if gem_info_hash[:version]
-    options ( gem_info_hash[:options]) if gem_info_hash[:options]
+    options gem_info_hash[:options] if gem_info_hash[:options]
   end
   chef_requires.push(gem_info_hash[:require_name] || gem_name)
 end

--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -31,6 +31,10 @@ create_directories
 
 d_owner = root_owner
 d_group = node['root_group']
+install_command = "chef-service-manager -a install -c #{File.join(node['chef_client']['conf_dir'], 'client.service.rb')}"
+if Chef::VERSION <= '12.5.1'
+  install_command << " -L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
+end
 
 template "#{node['chef_client']['conf_dir']}/client.service.rb" do
   source 'client.service.rb.erb'
@@ -40,8 +44,7 @@ template "#{node['chef_client']['conf_dir']}/client.service.rb" do
 end
 
 execute 'register-chef-service' do
-  command "chef-service-manager -a install -c #{File.join(node['chef_client']['conf_dir'], 'client.service.rb')} "\
-    "-L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
+  command install_command
   not_if { chef_client_service_running }
 end
 

--- a/spec/unit/windows_service_spec.rb
+++ b/spec/unit/windows_service_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'chef-client::windows_service' do
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'windows', version: '2012R2').converge(described_recipe) }
+
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:create_directories)
+    allow_any_instance_of(Chef::Resource).to receive(:chef_client_service_running)
+    allow_any_instance_of(Chef::Recipe).to receive(:root_owner).and_return('owner')
+  end
+
+  it 'should add log location to config' do
+    expect(chef_run).to render_file('C:/chef/client.service.rb')
+      .with_content(%r{log_location \"C:/chef/log/client.log\"})
+  end
+end

--- a/templates/windows/client.service.rb.erb
+++ b/templates/windows/client.service.rb.erb
@@ -2,6 +2,8 @@ if File.exists?(%q|<%= node["chef_client"]["conf_dir"] %>/client.rb|)
    Chef::Config.from_file(%q|<%= node["chef_client"]["conf_dir"] %>/client.rb|)
 end
 
+log_location "<%= File.join(node['chef_client']['log_dir'], 'client.log') %>"
+
 <% unless node["chef_client"]["interval"].nil? -%>
 interval <%= node["chef_client"]["interval"] %>
 <% end -%>

--- a/test/integration/cook-1951/serverspec/daemon_options_spec.rb
+++ b/test/integration/cook-1951/serverspec/daemon_options_spec.rb
@@ -3,5 +3,5 @@ require 'serverspec'
 set :backend, :exec
 
 describe process('chef-client') do
-  its(:args) { should match /-E cook-1951/ }
+  its(:args) { should match(/-E cook-1951/) }
 end


### PR DESCRIPTION
This PR depends on https://github.com/chef/chef/pull/4135

This will add the `log_location` to the client.service.rb and as long as the chef client version is greater than 12.5.1, it will not pass the `log_location` to the windows-service binary which will get the location from the client.service.config.

This will allow users to change the log location in the config whereas now the path is immutable after the service is installed.