### PR TITLE
Fix Ohai syntax for > 8.6.0 to remove deprecation warning.

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -82,6 +82,7 @@ template "#{node['chef_client']['conf_dir']}/client.rb" do
     chef_config: node['chef_client']['config'],
     chef_requires: chef_requires,
     ohai_disabled_plugins: node['ohai']['disabled_plugins'],
+    ohai_new_config_syntax: Gem::Requirement.new(">= 8.6.0").satisfied_by?(Gem::Version.new(Ohai::VERSION)),
     start_handlers: node['chef_client']['config']['start_handlers'],
     report_handlers: node['chef_client']['config']['report_handlers'],
     exception_handlers: node['chef_client']['config']['exception_handlers']

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -82,7 +82,7 @@ template "#{node['chef_client']['conf_dir']}/client.rb" do
     chef_config: node['chef_client']['config'],
     chef_requires: chef_requires,
     ohai_disabled_plugins: node['ohai']['disabled_plugins'],
-    ohai_new_config_syntax: Gem::Requirement.new(">= 8.6.0").satisfied_by?(Gem::Version.new(Ohai::VERSION)),
+    ohai_new_config_syntax: Gem::Requirement.new('>= 8.6.0').satisfied_by?(Gem::Version.new(Ohai::VERSION)),
     start_handlers: node['chef_client']['config']['start_handlers'],
     report_handlers: node['chef_client']['config']['report_handlers'],
     exception_handlers: node['chef_client']['config']['exception_handlers']

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -63,7 +63,7 @@ describe 'chef-client::config' do
 
     it 'specifies an ohai plugin path' do
       expect(chef_run).to render_file('/etc/chef/client.rb') \
-        .with_content(/ohai.plugin_path << "\/etc\/chef\/ohai_plugins"/)
+        .with_content(%(ohai.plugin_path << "/etc/chef/ohai_plugins"))
     end
 
     it 'converts log_level to a symbol' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -57,7 +57,7 @@ describe 'chef-client::config' do
 
     it 'disables ohai 6 & 7 plugins' do
       expect(chef_run).to render_file('/etc/chef/client.rb') \
-        .with_content(/Ohai::Config\[:disabled_plugins\] =\s+\[:passwd,"dmi"\]/)
+        .with_content(/ohai.disabled_plugins =\s+\[:passwd,"dmi"\]/)
     end
 
     it 'converts log_level to a symbol' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -42,6 +42,7 @@ describe 'chef-client::config' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
         node.set['ohai']['disabled_plugins'] = [:passwd, 'dmi']
+        node.set['ohai']['plugin_path'] = '/etc/chef/ohai_plugins'
         node.set['chef_client']['config']['log_level'] = ':debug'
         node.set['chef_client']['config']['ssl_verify_mode'] = ':verify_none'
         node.set['chef_client']['config']['exception_handlers'] = [{ class: 'SimpleReport::UpdatedResources', arguments: [] }]
@@ -58,6 +59,11 @@ describe 'chef-client::config' do
     it 'disables ohai 6 & 7 plugins' do
       expect(chef_run).to render_file('/etc/chef/client.rb') \
         .with_content(/ohai.disabled_plugins =\s+\[:passwd,"dmi"\]/)
+    end
+
+    it 'specifies an ohai plugin path' do
+      expect(chef_run).to render_file('/etc/chef/client.rb') \
+        .with_content(/ohai.plugin_path << "\/etc\/chef\/ohai_plugins"/)
     end
 
     it 'converts log_level to a symbol' do

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -45,7 +45,7 @@ no_proxy "<%= node["chef_client"]["config"]["no_proxy"] %>"
 Ohai::Config[:plugin_path] << "<%= node["ohai"]["plugin_path"] %>"
 <% end -%>
 <% unless @ohai_disabled_plugins.empty? -%>
-Ohai::Config[:disabled_plugins] = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]
+<%= @ohai_new_config_syntax? 'ohai.disabled_plugins' : 'Ohai::Config[:disabled_plugins]' %> = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]
 
 <% end -%>
 

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -42,7 +42,7 @@ no_proxy "<%= node["chef_client"]["config"]["no_proxy"] %>"
 
 <% if node.attribute?("ohai") && node["ohai"].attribute?("plugin_path") -%>
 
-Ohai::Config[:plugin_path] << "<%= node["ohai"]["plugin_path"] %>"
+<%= @ohai_new_config_syntax? 'ohai.plugin_path' : 'Ohai::Config[:plugin_path]' %> << "<%= node["ohai"]["plugin_path"] %>"
 <% end -%>
 <% unless @ohai_disabled_plugins.empty? -%>
 <%= @ohai_new_config_syntax? 'ohai.disabled_plugins' : 'Ohai::Config[:disabled_plugins]' %> = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]


### PR DESCRIPTION
This introduces the new Ohai config syntax that was introduced in 8.6.0. It removes the deprecation warning on every Chef run. 

```
[2015-10-22T15:03:46-04:00] WARN: Ohai::Config[:disabled_plugins] is set. 
Ohai::Config[:disabled_plugins] is deprecated and will be removed in future releases of ohai. Use 
ohai.disabled_plugins in your configuration file to configure :disabled_plugins for ohai.
```

Tested with Chef 12.5.1, the new syntax is loaded in the config file. 

```
ohai.disabled_plugins = [:Passwd]
```

Also changed the spec test to expect the new syntax so tests pass.

Let me know what you think. Closes #346.