### PR TITLE
Add support for daemon options in the windows task

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -28,12 +28,24 @@ client_bin = find_chef_client
 node.default['chef_client']['bin'] = client_bin
 create_directories
 
+# Build command line to pass to cmd.exe
+client_cmd = "#{node['chef_client']['ruby_bin']} #{node['chef_client']['bin']}"
+client_cmd << " -L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
+client_cmd << " -c #{File.join(node['chef_client']['conf_dir'], 'client.rb')}"
+client_cmd << " -s #{node['chef_client']['splay']}"
+
+# Add custom options
+client_cmd << " #{node['chef_client']['daemon_options'].join(' ')}" if node['chef_client']['daemon_options'].any?
+
+log 'debug client_cmd' do
+  message "Final client_cmd: #{client_cmd}"
+  level :debug
+end
+
 start_time = node['chef_client']['task']['frequency'] == 'minute' ? (Time.now + 60 * node['chef_client']['task']['frequency_modifier']).strftime('%H:%M') : nil
 windows_task 'chef-client' do
   run_level :highest
-  command "cmd /c \"#{node['chef_client']['ruby_bin']} #{node['chef_client']['bin']} \
-  -L #{File.join(node['chef_client']['log_dir'], 'client.log')} \
-  -c #{File.join(node['chef_client']['conf_dir'], 'client.rb')} -s #{node['chef_client']['splay']}\""
+  command "cmd /c \\\"#{client_cmd} > NUL 2>&1\\\""
 
   user               node['chef_client']['task']['user']
   password           node['chef_client']['task']['password']


### PR DESCRIPTION
Refactor the build of the command line for creating the windows scheduled task,
and add in daemon options array, as with the cron recipe.

Fixes #356 