### PR TITLE
Ensure upstart service picks up all config options

### DIFF
--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -37,6 +37,6 @@ service 'chef-client' do
   # This complication ensures (a) new splay/interval options are picked up and
   # (b) chef-client is running with the new config after restart is executed.
   #
-  restart_command 'nohup bash -c "trap SIGHUP SIGINT SIGTERM ; stop chef-client ; start chef-client"'
+  restart_command 'nohup bash -c "trap SIGHUP SIGINT SIGTERM ; stop chef-client ; sleep 1 ; start chef-client"'
   action [:enable, :start]
 end

--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -31,5 +31,12 @@ end
 
 service 'chef-client' do
   provider Chef::Provider::Service::Upstart
+  # Upstart doesn't reliably restart chef-client with the new splay/interval options.
+  # Either the old config is maintained, or the chef-client daemon dies.
+  #
+  # This complication ensures (a) new splay/interval options are picked up and
+  # (b) chef-client is running with the new config after restart is executed.
+  #
+  restart_command 'nohup bash -c "trap SIGHUP SIGINT SIGTERM ; stop chef-client ; start chef-client"'
   action [:enable, :start]
 end


### PR DESCRIPTION
Using upstart service does not reliably pick up the splay and interval
options.  This commit ensures that the options are picked up, and the
chef-client daemon is reliably restarted.  Simply using 'stop
chef-client ; start chef-client' results in a non-running daemon.
Combining the trap and nohup ensures the daemon runs with the new
config.
