### PR TITLE
Allow cmd arguments in cron definition

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,7 @@ default['chef_client']['cron'] = {
   'path' => nil,
   'environment_variables' => nil,
   'log_file' => '/dev/null',
+  'cmd_args' => '',
   'append_log' => false,
   'use_cron_d' => false,
   'mailto' => nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.3.3'
+version           '4.4.0'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::bluepill_service', 'Configures chef-client as a service under Bluepill'
 recipe 'chef-client::bsd_service', 'Configures chef-client as a service on *BSD'

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -78,6 +78,7 @@ end
 env        = node['chef_client']['cron']['environment_variables']
 log_file   = node['chef_client']['cron']['log_file']
 append_log = node['chef_client']['cron']['append_log'] ? '>>' : '>'
+cmd_args   = node['chef_client']['cron']['cmd_args']
 
 # Use daemon_options in cron.
 client_bin << " #{node['chef_client']['daemon_options'].join(' ')}" if node['chef_client']['daemon_options'].any?
@@ -98,7 +99,7 @@ if node['chef_client']['cron']['use_cron_d']
     user    'root'
     cmd = ''
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
-    cmd << "#{env} #{client_bin} #{append_log} #{log_file} 2>&1"
+    cmd << "#{env} #{client_bin} #{cmd_args} #{append_log} #{log_file} 2>&1"
     command cmd
   end
 else
@@ -115,7 +116,7 @@ else
     user    'root'
     cmd = ''
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
-    cmd << "#{env} #{client_bin} #{append_log} #{log_file} 2>&1"
+    cmd << "#{env} #{client_bin} #{cmd_args} #{append_log} #{log_file} 2>&1"
     command cmd
   end
 end


### PR DESCRIPTION
Ran into an issue where I need to run chef-client on cron but with specific command line arguments.
Unfortunately there doesn't seem to be a way of doing this currently.

Here's the end result i'm after:

`/usr/bin/chef-client --audit-mode audit_only`

This PR allows us to add custom params to the end of the chef-client.
