### PR TITLE
Remove support for Ubuntu 8.04-9.04

### DIFF
--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -12,14 +12,6 @@ create_directories
 upstart_job_dir = '/etc/init'
 upstart_job_suffix = '.conf'
 
-case node['platform']
-when 'ubuntu'
-  if (8.04..9.04).cover?(node['platform_version'].to_f)
-    upstart_job_dir = '/etc/event.d'
-    upstart_job_suffix = ''
-  end
-end
-
 template "#{upstart_job_dir}/chef-client#{upstart_job_suffix}" do
   source 'debian/init/chef-client.conf.erb'
   mode 0644


### PR DESCRIPTION
### Description

Removes support for Ubuntu distros that are EoL by the manufacturer and no longer supported by Chef

### Issues Resolved

#361 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


