### PR TITLE
Testing and documentation for scheduled tasks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,12 @@ platforms:
     provisioner:
       require_chef_omnibus: 11.18.6
   - name: ubuntu-15.04
+  - name: windows-2008r2
+    driver_config:
+      box: chef/windows-server-2008r2-standard # private box
+  - name: windows-2012r2
+    driver_config:
+      box: chef/windows-server-2012r2-standard # private box
 
 suites:
 
@@ -38,7 +44,7 @@ suites:
   run_list:
   - recipe[chef-client::config]
   - recipe[chef-client::init_service]
-  excludes: ["centos-7.2", "debian-8.2", "fedora-22", "fedora-23", "freebsd-9.3", "freebsd-10.2"]
+  includes: ["centos-5.11", "centos-6.7", "debian-7.9", "ubuntu-12.04", "ubuntu-14.04"]
 
 - name: service_runit
   run_list:
@@ -60,6 +66,7 @@ suites:
   run_list:
   - recipe[cron::default]
   - recipe[chef-client::cron]
+  excludes: ["windows-2008r2", "windows-2012r2"]
 
 - name: config
   run_list:
@@ -82,6 +89,7 @@ suites:
     chef_client:
       cron:
         use_cron_d: true
+  excludes: ["windows-2008r2", "windows-2012r2"]
 
 # Test that the running process includes command-line "daemon" options
 - name: cook-1951
@@ -92,7 +100,7 @@ suites:
     chef_client:
       init_style: "init"
       daemon_options: ["-E cook-1951"]
-  excludes: ["freebsd-9.3", "freebsd-10.2"]
+  excludes: ["freebsd-9.3", "freebsd-10.2", "windows-2008r2", "windows-2012r2"]
 
 # Testing when we are using chef-client on a Chef Server (12+ only)
 - name: server
@@ -100,3 +108,9 @@ suites:
   - recipe[chef-server]
   - recipe[chef-client::config]
   - recipe[chef-client::service]
+  includes: ["ubuntu-12.04", "ubuntu-14.04", "centos-6.7", "centos-7.2"]
+
+- name: task
+  run_list:
+    - recipe[chef-client::task]
+  includes: ["windows-2008r2", "windows-2012r2"]

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ Use this recipe on systems that should have a `chef-client` daemon running, such
 - `bsd` - prints a message about how to update BSD systems to enable the chef-client service, supported on Free/OpenBSD.
 
 ### default
+
 Includes the `chef-client::service` recipe by default.
 
 ### delete_validation
-Use this recipe to delete the validation certificate (default `/etc/chef/validation.pem`) when using a `chef-client` after the client has been validated and authorized to connect to the server.
 
-**Note** If you're using this on a Chef 10 Server, be careful when using this recipe. First, copy the `validation.pem` certificate file to another location, such as your knife configuration directory (`~/.chef`) or [Chef Repository](http://docs.chef.io/essentials_repository.html).
+Use this recipe to delete the validation certificate (default `/etc/chef/validation.pem`) when using a `chef-client` after the client has been validated and authorized to connect to the server.
 
 ### cron
 Use this recipe to run chef-client as a cron job rather than as a service. The cron job runs after random delay that is between 0 and 90 seconds to ensure that the chef-clients don't attempt to connect to the chef-server at the exact same time. You should set `node['chef_client']['init_style'] = 'none'` when you use this mode but it is not required.

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ As another example, to set HTTP proxy configuration settings. By default Chef wi
 default_attributes(
   "chef_client" => {
     "config" => {
-      "http_proxy" => "http://proxy.vmware.com:3128",
-      "https_proxy" => "http://proxy.vmware.com:3128",
+      "http_proxy" => "http://proxy.mycorp.com:3128",
+      "https_proxy" => "http://proxy.mycorp.com:3128",
       "http_proxy_user" => "my_username",
       "http_proxy_pass" => "Awe_some_Pass_Word!",
       "no_proxy" => "*.vmware.com,10.*"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 - `Chef::Config[:file_cache_path]` where chef-client will cache various files. Default is based on platform, falls back to "/var/chef/cache".
 - `node['chef_client']['backup_path']` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
 - `node['chef_client']['launchd_mode']` - (Only for Mac OS X) if set to `'daemon'`, runs chef-client with `-d` and `-s` options; defaults to `'interval'`.
-- When `chef_client['log_file']` is set and running on a [logrotate](http://ckbk.it/logrotate) supported platform (debian, rhel, fedora family), use the following attributes to tune log rotation.
+- When `chef_client['log_file']` is set and running on a [logrotate](https://supermarket.chef.io/cookbooks/logrotate) supported platform (debian, rhel, fedora family), use the following attributes to tune log rotation.
 
   - `node['chef_client']['logrotate']['rotate']` - Number of rotated logs to keep on disk, default 12.
   - `node['chef_client']['logrotate']['frequency']` - How often to rotate chef client logs, default weekly.
@@ -287,7 +287,7 @@ To dynamically render configuration for Start, Report, or Exception handlers, se
 - `report_handlers`
 - `exception_handlers`
 
-This is an alternative to using the [`chef_handler` cookbook](http://supermarket.chef.io/cookbooks/chef_handler).
+This is an alternative to using the [`chef_handler` cookbook](https://supermarket.chef.io/cookbooks/chef_handler).
 
 Each of these attributes must be an array of hashes. The hash has two keys, `class` (a string), and `arguments` (an array). For example, to use the report handler in the [Requiring Gems](#requiring-gems) section:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following platforms are tested directly under test-kitchen; see .kitchen.yml
 - Debian 7.9, 8.2
 - Fedora 22, 23
 - FreeBSD 9.3, 10.2
+- Windows 2008 R2 / Windows 2012 R2
 
 The following platforms are known to work:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Chef Client Cookbook
+
 [![Build Status](https://travis-ci.org/chef-cookbooks/chef-client.svg?branch=master)](https://travis-ci.org/chef-cookbooks/chef-client) [![Cookbook Version](https://img.shields.io/cookbook/v/chef-client.svg)](https://supermarket.chef.io/cookbooks/chef-client)
 
 This cookbook is used to configure a system as a Chef Client.
 
 ## Requirements
+
 ### Platforms
+
 The following platforms are tested directly under test-kitchen; see .kitchen.yml and TESTING.md for details.
+
 - Ubuntu 12.04, 14.04
 - CentOS 5.11, 6.7, 7.2
 - Debian 7.9, 8.2
@@ -13,6 +17,7 @@ The following platforms are tested directly under test-kitchen; see .kitchen.yml
 - FreeBSD 9.3, 10.2
 
 The following platforms are known to work:
+
 - Debian family (Debian, Ubuntu etc)
 - Red Hat family (Redhat, CentOS, Oracle etc)
 - Fedora family
@@ -27,15 +32,19 @@ The following platforms are known to work:
 Other platforms may work with or without modification. Most notably, attribute modification may be required.
 
 ### Chef
+
 - Chef 11.6.0+
 
 ### Dependent Cookbooks
+
 Some cookbooks can be used with this cookbook but they are not explicitly required. The default settings in this cookbook do not require their use. The other cookbooks (on the [supermarket](https://supermarket.chef.io/)) are:
+
 - bluepill
 - daemontools
 - runit
 
 Cron is a dependency, for default behavior of the `cron` recipe to work. This is a dependency because `cron` is cross platform, and doesn't carry additional dependencies, unlike the other cookbooks listed above.
+
 - cron 1.2.0+
 - logrotate 1.2.0+
 - windows 1.39.0+
@@ -43,7 +52,9 @@ Cron is a dependency, for default behavior of the `cron` recipe to work. This is
 See [USAGE](#usage).
 
 ## Attributes
+
 The following attributes affect the behavior of the chef-client program when running as a service through one of the service recipes, or in cron with the cron recipe, or are used in the recipes for various settings that require flexibility.
+
 - `node['chef_client']['interval']` - Sets `Chef::Config[:interval]` via command-line option for number of seconds between chef-client daemon runs. Default 1800.
 - `node['chef_client']['splay']` - Sets `Chef::Config[:splay]` via command-line option for a random amount of seconds to add to interval. Default 300.
 - `node['chef_client']['log_dir']` - Sets directory used in
@@ -69,6 +80,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['task']['password']` - The password for the user the scheduled task will run as, defaults to `nil` because the default user, `'SYSTEM'`, does not need a password.
 
 The following attributes are set on a per-platform basis, see the `attributes/default.rb` file for default values.
+
 - `node['chef_client']['init_style']` - Sets up the client service based on the style of init system to use. Default is based on platform and falls back to `'none'`. See [service recipes](#service-recipes).
 - `node['chef_client']['run_path']` - Directory location where chef-client should write the PID file. Default based on platform, falls back to "/var/run".
 - `node['chef_client']['cache_path']` - Directory location for
@@ -76,16 +88,20 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 - `node['chef_client']['backup_path']` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
 - `node['chef_client']['launchd_mode']` - (Only for Mac OS X) if set to `'daemon'`, runs chef-client with `-d` and `-s` options; defaults to `'interval'`.
 - When `chef_client['log_file']` is set and running on a [logrotate](http://ckbk.it/logrotate) supported platform (debian, rhel, fedora family), use the following attributes to tune log rotation.
+
   - `node['chef_client']['logrotate']['rotate']` - Number of rotated logs to keep on disk, default 12.
   - `node['chef_client']['logrotate']['frequency']` - How often to rotate chef client logs, default weekly.
 
 This cookbook makes use of attribute-driven configuration with this attribute. See [USAGE](#usage) for examples.
+
 - `node['chef_client']['config']` - A hash of Chef::Config keys and their values, rendered dynamically in `/etc/chef/client.rb`.
 - `node['chef_client']['load_gems']` - Hash of gems to load into chef via the client.rb file
 - `node['ohai']['disabled_plugins']` - An array of ohai plugins to disable, empty by default, and must be an array if specified. Ohai 6 plugins should be specified as a string (ie. "dmi"). Ohai 7+ plugins should be specified as a symbol within quotation marks (ie. ":Passwd").
 
 ### Chef Client Config
+
 The following attributes should be set using `['chef_client']['config']`. Setting them at the `['chef_client']` attribute level is **deprecated**.
+
 - `node['chef_client']['environment']` - Set the node's environment directly (useful for unattended installs when `knife bootstrap -E` is not an option).
 - `node['chef_client']['log_level']` - Not set anymore, use the default log level and output formatting in Chef 11+.
 - `node['chef_client']['server_url']` - Set by default with
@@ -98,17 +114,21 @@ The following attributes should be set using `['chef_client']['config']`. Settin
 - `node['chef_client']['verbose_logging']` - Not set anymore, we recommend using the default log level and output formatting in Chef 11+. This can still be set using `node['chef_client']['config']['verbose_logging']` if required.
 
 The following attributes are deprecated entirely.
+
 - `node['chef_client']['checksum_cache_skip_expires']` - No longer required in Chef 11+.
 
 ## Recipes
+
 This section describes the recipes in the cookbook and how to use them in your environment.
 
 ### config
+
 Sets up the `/etc/chef/client.rb` config file from a template and reloads the configuration for the current chef-client run.
 
 See [USAGE](#usage) for more information on how the configuration is rendered with attributes.
 
 ### service recipes
+
 The `chef-client::service` recipe includes one of the `chef-client::INIT_STYLE_service` recipes based on the attribute, `node['chef_client']['init_style']`. The individual service recipes can be included directly, too. For example, to use the init scripts, on a node or role's run list:
 
 ```
@@ -123,6 +143,7 @@ recipe[chef-client::runit_service]
 ```
 
 Use this recipe on systems that should have a `chef-client` daemon running, such as when Knife bootstrap was used to install Chef on a new system.
+
 - `init` - uses the init script included in this cookbook, supported on debian and redhat family distributions.
 - `upstart` - uses the upstart job included in this cookbook, supported on ubuntu.
 - `arch` - uses the init script included in this cookbook for ArchLinux, supported on arch.
@@ -141,9 +162,11 @@ Includes the `chef-client::service` recipe by default.
 Use this recipe to delete the validation certificate (default `/etc/chef/validation.pem`) when using a `chef-client` after the client has been validated and authorized to connect to the server.
 
 ### cron
+
 Use this recipe to run chef-client as a cron job rather than as a service. The cron job runs after random delay that is between 0 and 90 seconds to ensure that the chef-clients don't attempt to connect to the chef-server at the exact same time. You should set `node['chef_client']['init_style'] = 'none'` when you use this mode but it is not required.
 
 ## Usage
+
 Use the recipes as described above to configure your systems to run Chef as a service via cron or one of the service management systems supported by the recipes.
 
 The `chef-client::config` recipe is only _required_ with init style `init` (default setting for the attribute on debian/redhat family platforms, because the init script doesn't include the `pid_file` option which is set in the config.
@@ -190,6 +213,7 @@ default_attributes(
 ```
 
 ### Configuration Includes
+
 The `/etc/chef/client.rb` file will include all the configuration files in `/etc/chef/client.d/*.rb`. To create custom configuration, simply render a file resource with `file` (and the `content` parameter), `template`, `remote_file`, or `cookbook_file`. For example, in your own cookbook that requires custom Chef client configuration, create the following `cookbook_file` resource:
 
 ```ruby
@@ -225,6 +249,7 @@ log_location Chef::Log::Syslog.new('chef-client', ::Syslog::LOG_DAEMON)
 ```
 
 ### Requiring Gems
+
 Use the `load_gems` attribute to install gems that need to be required in the client.rb. This attribute should be a hash. The gem will also be installed with `chef_gem`. For example, suppose we want to use a Chef Handler Gem, `chef-handler-updated-resources`, which is used in the next heading. Set the attributes, e.g., in a role:
 
 ```ruby
@@ -255,7 +280,9 @@ end
 ```
 
 ### Start, Report, Exception Handlers
+
 To dynamically render configuration for Start, Report, or Exception handlers, set the following attributes in the `config` attributes:
+
 - `start_handlers`
 - `report_handlers`
 - `exception_handlers`
@@ -285,14 +312,17 @@ report_handlers << SimpleReport::UpdatedResources.new()
 ```
 
 ### Alternate Init Styles
+
 The alternate init styles available are:
+
 - runit
 - bluepill
 - daemontools
 - none -- should be specified if you are running chef-client as cron job
 
 #### Runit
-To use runit, download the cookbook from the cookbook site.
+
+To use runit, download the cookbook from Supermarket.
 
 Change the `init_style` to runit in the base role and add the runit recipe to the role's run list:
 
@@ -314,7 +344,8 @@ run_list(
 The `chef-client` recipe will create the chef-client service configured with runit. The runit run script will be located in `/etc/sv/chef-client/run`. The output log will be in the runit service directory, `/etc/sv/chef-client/log/main/current`.
 
 #### Bluepill
-To use bluepill, download the cookbook from the cookbook site.
+
+To use bluepill, download the cookbook from Supermarket.
 
 Change the `init_style` to runit in the base role and add the bluepill recipe to the role's run list:
 
@@ -336,7 +367,8 @@ run_list(
 The `chef-client` recipe will create the chef-client service configured with bluepill. The bluepill "pill" will be located in `/etc/bluepill/chef-client.pill`. The output log will be to client.log file in the `node['chef_client']['log_dir']` location, `/var/log/chef/client` by default.
 
 #### Daemontools
-To use daemontools, download the cookbook from the cookbook site.
+
+To use daemontools, download the cookbook from Supermarket.
 
 Change the `init_style` to runit in the base role and add the daemontools recipe to the role's run list:
 
@@ -358,17 +390,21 @@ run_list(
 The `chef-client` recipe will create the chef-client service configured under daemontools. It uses the same sv run scripts as the runit recipe. The run script will be located in `/etc/sv/chef-client/run`. The output log will be in the daemontools service directory, `/etc/sv/chef-client/log/main/current`.
 
 #### Launchd
+
 On Mac OS X and Mac OS X Server, the default service implementation is "launchd".
 
 Since launchd can run a service in interval mode, by default chef-client is not started in daemon mode like on Debian or Ubuntu. Keep this in mind when you look at your process list and check for a running chef process! If you wish to run chef-client in daemon mode, set attribute `chef_client.launchd_mode` to "daemon".
 
 ## Installing and updating chef-client
+
 This cookbook does not handle updating the chef-client, as that's out of the cookbook's current scope. To sensibly manage updates of the chef-client omnibus install, we refer you to:
+
 - [omnibus_updater](https://github.com/hw-cookbooks/omnibus_updater) - Heavy Water's cookbook for installing the omnibus Chef package and keeping your install up-to-date
 
 For more on why this cookbook does not support installs, see [Issue #102](https://github.com/chef-cookbooks/chef-client/pull/102)
 
 ## License & Authors
+
 **Author:** Cookbook Engineering Team ([cookbooks@chef.io](mailto:cookbooks@chef.io))
 
 **Copyright:** 2010-2016, Chef Software, Inc.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['cron']['environment_variables']` - Environment variables to pass to chef-client's execution (e.g. `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` chef-client)
 - `node['chef_client']['cron']['log_file']` - Location to capture the
 - `node['chef_client']['cron']['append_log']` - Whether to append to the log. Default: `false` chef-client output.
-- `node['chef_client']['cron']['use_cron_d']` - If true, use the [`cron_d` LWRP](https://github.com/chef-cookbooks/cron). If false (default), use the cron resource built-in to Chef.
+- `node['chef_client']['cron']['use_cron_d']` - If true, use the [`cron_d` resource](https://github.com/chef-cookbooks/cron). If false (default), use the cron resource built-in to Chef.
 - `node['chef_client']['cron']['mailto']` - If set, `MAILTO` env variable is set for cron definition
 - `node['chef_client']['reload_config']` - If true, reload Chef config of current Chef run when `client.rb` template changes (defaults to true)
 - `node['chef_client']['daemon_options']` - An array of additional options to pass to the chef-client service, empty by default, and must be an array if specified.
@@ -165,9 +165,13 @@ Use this recipe to delete the validation certificate (default `/etc/chef/validat
 
 Use this recipe to run chef-client as a cron job rather than as a service. The cron job runs after random delay that is between 0 and 90 seconds to ensure that the chef-clients don't attempt to connect to the chef-server at the exact same time. You should set `node['chef_client']['init_style'] = 'none'` when you use this mode but it is not required.
 
+### task
+
+Use this recipe to run chef-client on Windows nodes as a scheduled task. Without modifying attributes the scheduled task will run 30 minutes after the recipe runs, with each chef run rescheduling the run 30 minutes in the future. By default the job runs as the system user. The time period between runs can be modified with the `default['chef_client']['task']['frequency_modifier']` attribute and the user can be changed with the `default['chef_client']['task']['user']` and `default['chef_client']['task']['password']` attributes.
+
 ## Usage
 
-Use the recipes as described above to configure your systems to run Chef as a service via cron or one of the service management systems supported by the recipes.
+Use the recipes as described above to configure your systems to run Chef as a service via cron / scheduled task or one of the service management systems supported by the recipes.
 
 The `chef-client::config` recipe is only _required_ with init style `init` (default setting for the attribute on debian/redhat family platforms, because the init script doesn't include the `pid_file` option which is set in the config.
 


### PR DESCRIPTION
### Description

Adds testing and documentation for running chef-client as a scheduled task.  Also removes mention of Chef 10 server and the community site.

### Issues Resolved

#378

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

