### PR TITLE
add TERM exit status support to chef-client.service template

### DIFF
--- a/templates/default/systemd/chef-client.service.erb
+++ b/templates/default/systemd/chef-client.service.erb
@@ -6,6 +6,7 @@ After=network.target auditd.service
 EnvironmentFile=<%= @sysconfig_file %>
 ExecStart=<%= @client_bin %> -c $CONFIG -i $INTERVAL -s $SPLAY $OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
+SuccessExitStatus=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

This change adds SuccessExitStatus to the service attributes of the chef-client systemd unit file.

### Issues Resolved

This prevents systemd from marking the chef-client service as failed after a systemctl stop.
