### PR TITLE
Remove Chef 10 support and fix modes

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -91,7 +91,7 @@ suites:
   run_list:
   - recipe[chef-client::config]
   - recipe[chef-client::init_service]
-  includes: ["ubuntu-12.04", "ubuntu-14.04", "centos-6"]
+  includes: ["ubuntu-12.04", "ubuntu-14.04", "centos-6", "centos-5"]
 
 - name: service_runit
   run_list:

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -35,7 +35,7 @@ platforms:
     platform: rhel
     pid_one_command: /sbin/init
     provision_command:
-      - /usr/bin/yum install -y initscripts wget
+      - /usr/bin/yum install -y which initscripts
 
 - name: centos-6
   driver:
@@ -49,14 +49,14 @@ platforms:
     image: centos:7
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install lsof
+      - RUN yum -y install lsof which
 
 - name: fedora-23
   driver:
     image: fedora:23
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN dnf -y install yum
+      - RUN dnf -y install yum which
 
 - name: ubuntu-12.04
   driver:

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,44 +1,90 @@
-settings:
-  parallel: true
-
 driver:
-  name: docker
-  # privileged is required otherwise the container doesn't boot right
-  privileged: true
+  name: dokken
+  chef_version: latest
+  privileged: true # because Docker and SystemD/Upstart
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+verifier:
+  name: inspec
 
 platforms:
+- name: debian-7
+  driver:
+    image: debian:7
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install lsb-release -y
+
+- name: debian-8
+  driver:
+    image: debian:8
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install lsb-release -y
+
+- name: centos-5
+  driver:
+    image: centos:5
+    platform: rhel
+    pid_one_command: /sbin/init
+    provision_command:
+      - /usr/bin/yum install -y initscripts wget
+
 - name: centos-6
   driver:
     image: centos:6
-    platform: rhel
-    run_command: /sbin/init
-    provision_command:
-      - /usr/bin/yum install -y initscripts net-tools wget
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN yum -y install which initscripts
+
 - name: centos-7
   driver:
     image: centos:7
-    platform: rhel
-    run_command: /usr/lib/systemd/systemd
-    provision_command:
-      - /bin/yum install -y initscripts net-tools wget
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install lsof
+
+- name: fedora-23
+  driver:
+    image: fedora:23
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN dnf -y install yum
+
 - name: ubuntu-12.04
   driver:
     image: ubuntu-upstart:12.04
-    platform: ubuntu
-    disable_upstart: false
-    run_command: /sbin/init
-    provision_command:
-      - /usr/bin/apt-get update
-      - /usr/bin/apt-get install apt-transport-https net-tools -y
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04
-    platform: ubuntu
-    disable_upstart: false
-    run_command: /sbin/init
-    provision_command:
-      - /usr/bin/apt-get update
-      - /usr/bin/apt-get install apt-transport-https net-tools -y
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+
+- name: opensuse-13.2
+  driver:
+    image: opensuse:13.2
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN zypper refresh
 
 suites:
 - name: service_init

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,28 @@ addons:
     packages:
       - chefdk
 
+install: echo "skip bundle install"
+
 services: docker
 
 env:
   matrix:
   - INSTANCE=cron-ubuntu-1204
   - INSTANCE=cron-ubuntu-1404
+  - INSTANCE=cron-ubuntu-1604
+  - INSTANCE=cron-centos-5
   - INSTANCE=cron-centos-6
   - INSTANCE=cron-centos-7
   - INSTANCE=config-ubuntu-1204
   - INSTANCE=config-ubuntu-1404
+  - INSTANCE=config-ubuntu-1604
+  - INSTANCE=config-centos-5
   - INSTANCE=config-centos-6
   - INSTANCE=config-centos-7
   - INSTANCE=delete-validation-ubuntu-1204
   - INSTANCE=delete-validation-ubuntu-1404
+  - INSTANCE=delete-validation-ubuntu-1604
+  - INSTANCE=delete-validation-centos-5
   - INSTANCE=delete-validation-centos-6
   - INSTANCE=delete-validation-centos-7
   - INSTANCE=service-upstart-ubuntu-1204
@@ -30,23 +38,21 @@ env:
   - INSTANCE=service-systemd-centos-7
   - INSTANCE=service-init-ubuntu-1204
   - INSTANCE=service-init-ubuntu-1404
+  - INSTANCE=service-init-centos-5
   - INSTANCE=service-init-centos-6
 
-# Don't `bundle install`
-install: echo "skip bundle install"
+  fast_finish: true
 
-# Ensure we make ChefDK's Ruby the default
 before_script:
-  # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef gem install kitchen-docker
-  - /opt/chefdk/embedded/bin/chef gem install rubocop -v 0.37
+  - /opt/chefdk/embedded/bin/chef gem install kitchen-dokken
+
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version
   - /opt/chefdk/embedded/bin/rubocop
   - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
+  - /opt/chefdk/embedded/bin/foodcritic . --exclude spec -f any
   - /opt/chefdk/embedded/bin/rspec
   - KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}

--- a/Gemfile
+++ b/Gemfile
@@ -1,31 +1,13 @@
 source 'https://rubygems.org'
 
-group :rake do
-  gem 'rake'
-  gem 'tomlrb'
-end
-
-group :lint do
-  gem 'foodcritic', '~> 6.0'
-  gem 'rubocop', '~> 0.38'
-end
-
-group :unit do
-  gem 'berkshelf', '~> 4.3'
-  gem 'chefspec', '~> 4.6'
-end
-
-group :kitchen_common do
-  gem 'test-kitchen', '~> 1.7'
-  # Windows specific, but kitchen won't work without these.
-  gem 'winrm', '~> 1.6'
-  gem 'winrm-fs', '~> 0.4.1'
-end
-
-group :kitchen_vagrant do
-  gem 'kitchen-vagrant', '~> 0.19'
-end
-
-group :release do
-  gem 'stove'
-end
+gem 'berkshelf', '~> 4.3'
+gem 'chefspec', '~> 4.6'
+gem 'foodcritic', '~> 6.2'
+gem 'kitchen-dokken'
+gem 'kitchen-inspec', '~> 0.12'
+gem 'kitchen-vagrant', '~> 0.20'
+gem 'rake'
+gem 'rubocop', '~> 0.38'
+gem 'stove'
+gem 'test-kitchen', '~> 1.7'
+gem 'tomlrb'

--- a/recipes/bluepill_service.rb
+++ b/recipes/bluepill_service.rb
@@ -15,14 +15,14 @@ directory node['chef_client']['run_path'] do
   recursive true
   owner 'root'
   group group
-  mode 0755
+  mode 00755
 end
 
 include_recipe 'bluepill' # ~FC007: bluepill is only required when using the bluepill_service recipe
 
 template "#{node['bluepill']['conf_dir']}/chef-client.pill" do
   source 'chef-client.pill.erb'
-  mode 0644
+  mode 00644
   notifies :restart, 'bluepill_service[chef-client]', :delayed
 end
 

--- a/recipes/bsd_service.rb
+++ b/recipes/bsd_service.rb
@@ -26,11 +26,11 @@ when 'freebsd'
     owner 'root'
     group 'wheel'
     variables client_bin: client_bin
-    mode 0755
+    mode 00755
   end
 
   template '/etc/rc.conf.d/chef' do
-    mode 0644
+    mode 00644
     notifies :start, 'service[chef-client]', :delayed
   end
 

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -50,7 +50,7 @@ when 'arch', 'debian', 'rhel', 'fedora', 'suse', 'openbsd', 'freebsd'
 
   template "/etc/#{conf_dir}/chef-client" do
     source "#{dist_dir}/#{conf_dir}/chef-client.erb"
-    mode 0644
+    mode 00644
   end
 
   service 'chef-client' do

--- a/recipes/daemontools_service.rb
+++ b/recipes/daemontools_service.rb
@@ -17,7 +17,7 @@ directory '/etc/sv/chef-client' do
   recursive true
   owner 'root'
   group group
-  mode 0755
+  mode 00755
 end
 
 daemontools_service 'chef-client' do

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -18,14 +18,14 @@ dist_dir, conf_dir = value_for_platform_family(
 
 template '/etc/init.d/chef-client' do
   source "#{dist_dir}/init.d/chef-client.erb"
-  mode 0755
+  mode 00755
   variables client_bin: client_bin
   notifies :restart, 'service[chef-client]', :delayed
 end
 
 template "/etc/#{conf_dir}/chef-client" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
-  mode 0644
+  mode 00644
   notifies :restart, 'service[chef-client]', :delayed
 end
 

--- a/recipes/launchd_service.rb
+++ b/recipes/launchd_service.rb
@@ -11,34 +11,26 @@ Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 
-version_checker = Gem::Requirement.new('>= 0.10.10')
-mac_service_supported = version_checker.satisfied_by?(Gem::Version.new(node['chef_packages']['chef']['version']))
+file '/Library/LaunchDaemons/com.opscode.chef-client.plist' do
+  action :delete
+  notifies :stop, 'service[com.opscode.chef-client]'
+end
 
-if mac_service_supported
+template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
+  source 'com.chef.chef-client.plist.erb'
+  mode 00644
+  variables(
+    launchd_mode: node['chef_client']['launchd_mode'],
+    client_bin: client_bin
+  )
+end
 
-  file '/Library/LaunchDaemons/com.opscode.chef-client.plist' do
-    action :delete
-    notifies :stop, 'service[com.opscode.chef-client]'
-  end
+service 'com.opscode.chef-client' do
+  action :nothing
+end
 
-  template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
-    source 'com.chef.chef-client.plist.erb'
-    mode 0644
-    variables(
-      launchd_mode: node['chef_client']['launchd_mode'],
-      client_bin: client_bin
-    )
-  end
-
-  service 'com.opscode.chef-client' do
-    action :nothing
-  end
-
-  service 'chef-client' do
-    service_name 'com.chef.chef-client'
-    provider Chef::Provider::Service::Macosx
-    action :start
-  end
-else
-  log('Mac OS X Service provider is only supported in Chef >= 0.10.10') { level :warn }
+service 'chef-client' do
+  service_name 'com.chef.chef-client'
+  provider Chef::Provider::Service::Macosx
+  action :start
 end

--- a/recipes/smf_service.rb
+++ b/recipes/smf_service.rb
@@ -27,7 +27,7 @@ template "#{node['chef_client']['method_dir']}/chef-client" do
 end
 
 template(local_path + 'chef-client.xml') do
-  if node[:platform_version].to_f >= 5.11
+  if node['platform_version'].to_f >= 5.11
     source 'solaris/manifest-5.11.xml.erb'
   else
     source 'solaris/manifest.xml.erb'

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -17,14 +17,14 @@ dist_dir, conf_dir, env_file = value_for_platform_family(
 
 template '/etc/systemd/system/chef-client.service' do
   source 'systemd/chef-client.service.erb'
-  mode 0644
+  mode 00644
   variables(client_bin: client_bin, sysconfig_file: "/etc/#{conf_dir}/#{env_file}")
   notifies :restart, 'service[chef-client]', :delayed
 end
 
 template "/etc/#{conf_dir}/#{env_file}" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
-  mode 0644
+  mode 00644
   notifies :restart, 'service[chef-client]', :delayed
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,2 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
-
-at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -41,28 +41,35 @@ describe 'chef-client::service' do
   end
 
   context 'Fedora' do
-    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '20').converge(described_recipe) }
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'fedora', version: '23').converge(described_recipe) }
     it 'should use the systemd service' do
       expect(chef_run).to include_recipe('chef-client::systemd_service')
     end
   end
 
-  context 'FreeBSD' do
+  context 'FreeBSD 9' do
     let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'freebsd', version: '9.2').converge(described_recipe) }
     it 'should use the bsd service' do
       expect(chef_run).to include_recipe('chef-client::bsd_service')
     end
   end
 
+  context 'FreeBSD 10' do
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'freebsd', version: '10.3').converge(described_recipe) }
+    it 'should use the bsd service' do
+      expect(chef_run).to include_recipe('chef-client::bsd_service')
+    end
+  end
+
   context 'Mac OS X' do
-    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.8.2').converge(described_recipe) }
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe) }
     it 'should use the launchd service' do
       expect(chef_run).to include_recipe('chef-client::launchd_service')
     end
   end
 
   context 'OpenSuSE' do
-    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'opensuse', version: '13.1').converge(described_recipe) }
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'opensuse', version: '13.2').converge(described_recipe) }
     it 'should use the init service' do
       expect(chef_run).to include_recipe('chef-client::init_service')
     end


### PR DESCRIPTION
### Description

We no longer support Chef 10 in this cookbook. We can remove Chef 10 checks

### Issues Resolved

N/A

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Signed-off-by: Tim Smith <tsmith@chef.io>