### PR TITLE
Fix regression introduced in 4.5.1

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,7 +20,7 @@ module Opscode
   module ChefClient
     # helper methods for use in chef-client recipe code
     module Helpers
-      include Chef::Mixin::Which
+      include Chef::Mixin::Which if defined?(Chef::Mixin::Which)
       include Chef::DSL::PlatformIntrospection
 
       def wmi_property_from_query(wmi_property, wmi_query)
@@ -91,7 +91,10 @@ module Opscode
           Chef::Log.debug 'Using chef-client bin from sane path'
           chef_in_sane_path
         # last ditch search for a bin in PATH
-        elsif (chef_in_path = which('chef-client')) != false
+        elsif defined?(which) && (chef_in_path = which('chef-client')) != false
+          Chef::Log.debug 'Using chef-client bin from system path'
+          chef_in_path
+        elsif (chef_in_path = `#{which} chef-client`.chomp) && ::File.send(existence_check, chef_in_path) # ~FC048 Prefer Mixlib::ShellOut is ignored here
           Chef::Log.debug 'Using chef-client bin from system path'
           chef_in_path
         else


### PR DESCRIPTION
### Description

`Chef::Mixin::Which` was introduced relatively recently, so the newest
release created some incompatibilities:

```
================================================================================
Recipe Compile Error in /tmp/kitchen/cache/cookbooks/chef-client/libraries/helpers.rb
================================================================================

NameError
---------
uninitialized constant Chef::Mixin::Which

Cookbook Trace:
---------------
  /tmp/kitchen/cache/cookbooks/chef-client/libraries/helpers.rb:23:in `<module:Helpers>'
  /tmp/kitchen/cache/cookbooks/chef-client/libraries/helpers.rb:22:in `<module:ChefClient>'
  /tmp/kitchen/cache/cookbooks/chef-client/libraries/helpers.rb:20:in `<module:Opscode>'
  /tmp/kitchen/cache/cookbooks/chef-client/libraries/helpers.rb:19:in `<top (required)>'
```

The chef-11 Kitchen platforms pass again after making this change.

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD