### PR TITLE
Automatically restart systemd service on failure

### DIFF
--- a/templates/default/systemd/chef-client.service.erb
+++ b/templates/default/systemd/chef-client.service.erb
@@ -6,6 +6,7 @@ After=network.target auditd.service
 EnvironmentFile=<%= @sysconfig_file %>
 ExecStart=<%= @client_bin %> -c $CONFIG -i $INTERVAL -s $SPLAY $OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

The systemd service file provides a `Restart` option allowing you to
specify the conditions under which a service is automatically restarted.

Passing a value of `on-failure` ensures that the Chef client is
restarted in the event of a hard failure such as a segmentation fault or
OOM process killer.