### PR TITLE
Let the windows task escape the quotes and lose the stream redirection

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -36,7 +36,7 @@ suggests 'runit'
 
 depends 'cron', '>= 1.7.0'
 depends 'logrotate', '>= 1.9.0'
-depends 'windows', '>= 1.39.0'
+depends 'windows', '>= 1.42.0'
 
 source_url 'https://github.com/chef-cookbooks/chef-client' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/chef-client/issues' if respond_to?(:issues_url)

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -31,9 +31,9 @@ create_directories
 start_time = node['chef_client']['task']['frequency'] == 'minute' ? (Time.now + 60 * node['chef_client']['task']['frequency_modifier']).strftime('%H:%M') : nil
 windows_task 'chef-client' do
   run_level :highest
-  command "cmd /c \\\"#{node['chef_client']['ruby_bin']} #{node['chef_client']['bin']} \
+  command "cmd /c \"#{node['chef_client']['ruby_bin']} #{node['chef_client']['bin']} \
   -L #{File.join(node['chef_client']['log_dir'], 'client.log')} \
-  -c #{File.join(node['chef_client']['conf_dir'], 'client.rb')} -s #{node['chef_client']['splay']} > NUL 2>&1\\\""
+  -c #{File.join(node['chef_client']['conf_dir'], 'client.rb')} -s #{node['chef_client']['splay']}\""
 
   user               node['chef_client']['task']['user']
   password           node['chef_client']['task']['password']


### PR DESCRIPTION
This depends on https://github.com/chef-cookbooks/windows/pull/365 and will need to update the windows cookbook dependency constraint once that has been merged.

Currently the task recipe is not idempotent. See also this [discource discussion](https://discourse.chef.io/t/is-chef-client-task-recipe-supposed-to-be-idempotent/8540/7). With the changes to the windows cookbook, this should no longer need to escape the quotes of the task command since the task resource will manage that. Also this drops the stream redirection since the task (for reasons I dont know why) strips that from the task action.
