### PR TITLE
Use SYSTEM as the directory owner

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,8 +34,8 @@ module Opscode
       end
 
       def root_owner
-        if ['windows'].include?(node['platform'])
-          wmi_property_from_query(:name, "select * from Win32_UserAccount where sid like 'S-1-5-21-%-500' and LocalAccount=True")
+        if platform?('windows')
+          'SYSTEM'
         else
           'root'
         end


### PR DESCRIPTION
### Description

We're currently trying to find a local admin account, but that won't exist on a DC.  SYSTEM will always exist and administrators group still has write on the dirs so this is really no change.

### Issues Resolved

#333 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


We're currently trying to find a local admin account, but that won't exist on a DC.  SYSTEM will always exist and administrators group still has write on the dirs so this is really no change.