### PR TITLE
Explicitly load files in client.d only for Chef 12.7 or older

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -68,6 +68,7 @@ rescue NameError => e
   Chef::Log.error e
 end
 
+<% if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.8') -%>
 Dir.glob(File.join(<%= node['chef_client']['conf_dir'].inspect %>, "client.d", "*.rb")).each do |conf|
   <% if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.4.0') -%>
   Chef::Config.from_file(conf)
@@ -75,3 +76,4 @@ Dir.glob(File.join(<%= node['chef_client']['conf_dir'].inspect %>, "client.d", "
   ChefConfig::Config.from_file(conf)
   <% end -%>
 end
+<% end -%>


### PR DESCRIPTION
Change the rendered `client.rb` file to include files in `client.d` _only if_ running a version of Chef < 12.8.

Chef 12.8+ includes support for automatically loading files in the `/etc/chef/client.d` directory [1]. This results in files being loaded twice if you are using the `chef-client` cookbook with a recent version of the Chef client, which can be problematic in certain situations (e.g. defining a custom formatter which is loaded twice results in duplicated output).

[1] https://docs.chef.io/release/12-8/release_notes.html