### PR TITLE
support for controlling cron mode with an init_style attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Use this recipe to delete the validation certificate (default `/etc/chef/validat
 
 ### cron
 
-Use this recipe to run chef-client as a cron job rather than as a service. The cron job runs after random delay that is between 0 and 90 seconds to ensure that the chef-clients don't attempt to connect to the chef-server at the exact same time. You should set `node['chef_client']['init_style'] = 'none'` when you use this mode but it is not required.
+Use this recipe to run chef-client as a cron job rather than as a service. The cron job runs after random delay that is between 0 and 90 seconds to ensure that the chef-clients don't attempt to connect to the chef-server at the exact same time. You can alternatively have the "default" recipe in the run_list and set `node['chef_client']['init_style'] = 'cron'` to have "cron" recipe included. It is not required if you put the recipe in the run_list manually.
 
 ### task
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.6.0'
+version           '4.7.0'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::bluepill_service', 'Configures chef-client as a service under Bluepill'
 recipe 'chef-client::bsd_service', 'Configures chef-client as a service on *BSD'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -40,6 +40,8 @@ init_style = node['chef_client']['init_style']
 # Services moved to recipes
 if supported_init_styles.include? init_style
   include_recipe "chef-client::#{init_style}_service"
+elsif init_style == "cron"
+  include_recipe "chef-client::cron"
 else
   log 'Could not determine service init style, manual intervention required to start up the chef-client service.'
 end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -70,8 +70,29 @@ describe 'chef-client::service' do
 
   context 'OpenSuSE' do
     let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'opensuse', version: '13.2').converge(described_recipe) }
+    it 'should use the systemd service' do
+      expect(chef_run).to include_recipe('chef-client::systemd_service')
+    end
+  end
+
+  context 'Ubuntu 12.04' do
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '12.04').converge(described_recipe) }
     it 'should use the init service' do
       expect(chef_run).to include_recipe('chef-client::init_service')
+    end
+  end
+
+  context 'Ubuntu 14.04' do
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe) }
+    it 'should use the init service' do
+      expect(chef_run).to include_recipe('chef-client::init_service')
+    end
+  end
+
+  context 'Ubuntu 16.04' do
+    let(:chef_run) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+    it 'should use the systemd service' do
+      expect(chef_run).to include_recipe('chef-client::systemd_service')
     end
   end
 


### PR DESCRIPTION
### Description

Currently I am able to control the way I run chef-client as a service with "init_style" attribute, while having only "default" recipe in the run_list. I would like to achieve the same, consistent style of control for running chef-client using cron, with "init_style" set to "cron" (although naming... technically cron does not have to do with init). 

Example use case: Imagine one is switching from running chef-client as a service to running it as cron job and he would like to experiment in one of environments first without having to manipulate run lists. 
### Issues Resolved

none
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
