### PR TITLE
Bug Fix removing extra slach characters

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -45,7 +45,7 @@ end
 start_time = node['chef_client']['task']['frequency'] == 'minute' ? (Time.now + 60 * node['chef_client']['task']['frequency_modifier']).strftime('%H:%M') : nil
 windows_task 'chef-client' do
   run_level :highest
-  command "cmd /c \\\"#{client_cmd} > NUL 2>&1\\\""
+  command "cmd /c \"#{client_cmd} > NUL 2>&1\""
 
   user               node['chef_client']['task']['user']
   password           node['chef_client']['task']['password']


### PR DESCRIPTION
### Description

The following error occurs when you run the task recipe since v5. 

Expected process to exit with [0], but received '-2147467259'

### Issues Resolved

As above

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


To stop the following error

Expected process to exit with [0], but received '-2147467259'