### PR TITLE
Remove extra `Windows 2008 R2+` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This cookbook is used to configure a system as a Chef Client.
 - Solaris 10+
 - Ubuntu 12.04+
 - Windows 2008 R2+
-- Windows 2008 R2+
 
 ### Chef
 


### PR DESCRIPTION
This removes the extra `Windows 2008 R2+` line in `README.md`


