### PR TITLE
Don't explode under chef-solo.

### DIFF
--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -23,7 +23,13 @@ end
 
 # Don't do anything run running as solo. This can happen when using ChefSpec or
 # Test Kitchen.
-return if Chef::Config[:solo]
+if Chef::Config[:solo]
+  if !ENV['TEST_KITCHEN'] && !defined?(ChefSpec)
+    Chef::Log.info("[chef-client::delete_validation] Skipping validation " \
+      "delete because we are running under chef-solo")
+  end
+  return
+end
 
 unless Chef::Config[:validation_key].nil?
   file Chef::Config[:validation_key] do

--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -21,6 +21,10 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
+# Don't do anything run running as solo. This can happen when using ChefSpec or
+# Test Kitchen.
+return if Chef::Config[:solo]
+
 unless Chef::Config[:validation_key].nil?
   file Chef::Config[:validation_key] do
     action :delete


### PR DESCRIPTION
Specifically `Chef::Config[:client_key]` is generally going to be nil under solo, and `exist?` doesn't like being passed nil. Regardless, this should be a no-op under solo.