### PR TITLE
Change path for rc.d script in FreeBSD

### DIFF
--- a/recipes/bsd_service.rb
+++ b/recipes/bsd_service.rb
@@ -29,6 +29,11 @@ when 'freebsd'
     mode 00755
   end
 
+  # Remove wrong rc.d script created by an older version of cookbook
+  file '/etc/rc.d/chef-client' do
+    action :delete
+  end
+
   template '/etc/rc.conf.d/chef' do
     mode 00644
     notifies :start, 'service[chef-client]', :delayed

--- a/recipes/bsd_service.rb
+++ b/recipes/bsd_service.rb
@@ -22,7 +22,7 @@ when 'freebsd'
     action :create
   end
 
-  template '/etc/rc.d/chef-client' do
+  template '/usr/local/etc/rc.d/chef-client' do
     owner 'root'
     group 'wheel'
     variables client_bin: client_bin

--- a/templates/freebsd/chef-client.erb
+++ b/templates/freebsd/chef-client.erb
@@ -10,6 +10,6 @@ name="chef"
 pidfile="<%= node["chef_client"]["run_path"] %>/${name}.pid"
 command="<%= @client_bin %>"
 command_interpreter="<%= RbConfig.ruby %>"
-command_args="-i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -d -P <%= node["chef_client"]["run_path"] %>/${name}.pid"
+command_args="-i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> -d -P ${pidfile}"
 load_rc_config $name
 run_rc_command "$1"


### PR DESCRIPTION
### Description

In FreeBSD /etc/rc.d is for system services only. Every init script installed by packages always goes to /usr/local. This is not a bug, but it violates the FreeBSD file system hierarchy. Other files you put it /etc are all correct. I did two commits, not sure if second is required.

### Check List
- [+] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [-] New functionality includes testing.
- [-] New functionality has been documented in the README if applicable
- [+] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

