### PR TITLE
fix escaping

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -45,7 +45,7 @@ end
 start_time = node['chef_client']['task']['frequency'] == 'minute' ? (Time.now + 60 * node['chef_client']['task']['frequency_modifier']).strftime('%H:%M') : nil
 windows_task 'chef-client' do
   run_level :highest
-  command "cmd /c \\\"#{client_cmd} > NUL 2>&1\\\""
+  command "cmd /c \"#{client_cmd} ^> NUL 2^>^&1\""
 
   user               node['chef_client']['task']['user']
   password           node['chef_client']['task']['password']

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'chef-client::task' do
+  context 'when given override attributes' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'windows', version: '2012R2') do |node|
+        node.override['chef_client']['task']['start_time'] = 'Tue Sep 13 15:46:33 EDT 2016'
+        node.override['chef_client']['task']['user'] = 'system'
+        node.override['chef_client']['task']['password'] = 'secret'
+        node.override['chef_client']['task']['frequency'] = 'hourly'
+        node.override['chef_client']['task']['frequency_modifier'] = 60
+      end.converge(described_recipe)
+    end
+
+    before(:each) do
+      allow(File).to receive(:exists?).and_call_original
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:exists?).with('C:/opscode/chef/bin/chef-client').and_return(true)
+      allow_any_instance_of(Chef::Recipe).to receive(:create_directories)
+      allow_any_instance_of(Chef::Resource).to receive(:chef_client_service_running)
+      allow_any_instance_of(Chef::Recipe).to receive(:root_owner).and_return('owner')
+    end
+
+    it 'creates the windows_task resource with desired settings' do
+      expect(chef_run).to create_windows_task('chef-client').with(
+        command: 'cmd /c " C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300 ^> NUL 2^>^&1"',
+        user: 'system',
+        password: 'secret',
+        frequency: :hourly,
+        frequency_modifier: 60,
+        start_time: 'Tue Sep 13 15:46:33 EDT 2016'
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Description

The escaping is incorrect for the Windows task recipe when constructing the command for the `windows_task` resource.

1. There are superfluous escape backslash (`\`) characters before the `"`, just one escape suffices.
2. The `>` and `&` characters are special characters that also need to be escaped with `^`.  See http://www.robvanderwoude.com/escapechars.php

### Issues Resolved

This PR resolves #417 

@KirkMartinez had already resolved the issue manually, this PR just incorporates his fix.

```
       Recipe: chef-client::task
         * directory[C:/chef/run] action create (up to date)
         * directory[C:/chef/cache] action create (up to date)
         * directory[C:/chef/backup] action create (up to date)
         * directory[C:/chef/log] action create (up to date)
         * directory[C:/chef] action create (up to date)
         * log[debug client_cmd] action write

         * windows_task[chef-client] action create

       Recipe: chef-client::config
         * file[C:/chef/log/client.log] action create[2016-09-13T11:35:04-07:00] WARN: Mode 640 includes bits for the owner, but owner is not specified
       [2016-09-13T11:35:04-07:00] WARN: Mode 640 includes bits for the group, but group is not specified
        (up to date)
         * template[C:/chef/client.rb] action create (up to date)
         * directory[C:/chef/client.d] action create (up to date)
         * ruby_block[reload_client_config] action nothing (skipped due to action :nothing)
         * ruby_block[reload_client_config] action create
           - execute the ruby block reload_client_config

       Running handlers:
       Running handlers complete
```

This has been tested with TK on Windows 2012R2.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
