### PR TITLE
Adding exception to 5.11 SMF manifest for SmartOS. SmartOS does not h…

### DIFF
--- a/recipes/smf_service.rb
+++ b/recipes/smf_service.rb
@@ -27,7 +27,7 @@ template "#{node['chef_client']['method_dir']}/chef-client" do
 end
 
 template(local_path + 'chef-client.xml') do
-  if node['platform_version'].to_f >= 5.11
+  if node['platform_version'].to_f >= 5.11 && node['platform'] != 'smartos'
     source 'solaris/manifest-5.11.xml.erb'
   else
     source 'solaris/manifest.xml.erb'


### PR DESCRIPTION
### Description

Cookbook version 4.3.3 added a Solaris 5.11 specific manifest. The fix moved the service milestone from sysconfig to config. Unfortunately SmartOS still uses the sysconfig milestone but identifies as platform version 5.11. This changes adds an exception so that the chef-client service will be properly installed in SmartOS.

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

…ave a config milestone