### PR TITLE
Doc: fixing information about cron attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.
 - `node['chef_client']['conf_dir']` - Sets directory used via command-line option to a location where chef-client search for the client config file . Default "/etc/chef".
 - `node['chef_client']['bin']` - Sets the full path to the `chef-client` binary. Mainly used to set a specific path if multiple versions of chef-client exist on a system or the bin has been installed in a non-sane path. Default "/usr/bin/chef-client".
-- `node['chef_client']['cron']['minute']` - The minute that chef-client will run as a cron task, only applicable if you set `'cron'` as the `'init_style'`
-- `node['chef_client']['cron']['hour']` - The hour that chef-client will run as a cron task, only applicable if you set `'cron'` as the `'init_style'`
-- `node['chef_client']['cron']['weekday']` - The weekday that chef-client will run as a cron task, only applicable if you set `'cron'` as the `'init_style'`
+- `node['chef_client']['cron']['minute']` - The minute that chef-client will run as a cron task. See [cron recipe](#cron)
+- `node['chef_client']['cron']['hour']` - The hour that chef-client will run as a cron task. See [cron recipe](#cron)
+- `node['chef_client']['cron']['weekday']` - The weekday that chef-client will run as a cron task. See [cron recipe](#cron)
 - `node['chef_client']['cron']['environment_variables']` - Environment variables to pass to chef-client's execution (e.g. `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` chef-client)
 - `node['chef_client']['cron']['log_file']` - Location to capture the
 - `node['chef_client']['cron']['append_log']` - Whether to append to the log. Default: `false` chef-client output.


### PR DESCRIPTION
### Description

There is no init_style cron. Lets have a link to the cron recipe documentation.