### PR TITLE
Fix init service detection

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,6 +1,7 @@
 driver:
   name: dokken
-  chef_version: latest
+  chef_image: chef/chef
+  chef_version: current
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,8 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_omnibus_url: "https://omnitruck.chef.io/install.sh"
+  chef_omnibus_install_options: "-c current"
 
 verifier:
   name: inspec

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -100,7 +100,7 @@ directory ::File.join(node['chef_client']['conf_dir'], 'client.d') do
   recursive true
   owner d_owner
   group node['root_group']
-  mode "755"
+  mode '755'
 end
 
 ruby_block 'reload_client_config' do

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -72,7 +72,7 @@ when 'freebsd'
     owner 'root'
     group 'wheel'
     variables client_bin: client_bin
-    mode "755"
+    mode '755'
   end
 
   file '/etc/rc.conf.d/chef' do

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -18,14 +18,14 @@ dist_dir, conf_dir = value_for_platform_family(
 
 template '/etc/init.d/chef-client' do
   source "#{dist_dir}/init.d/chef-client.erb"
-  mode "755"
+  mode '755'
   variables client_bin: client_bin
   notifies :restart, 'service[chef-client]', :delayed
 end
 
 template "/etc/#{conf_dir}/chef-client" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
-  mode "644"
+  mode '644'
   notifies :restart, 'service[chef-client]', :delayed
 end
 

--- a/recipes/launchd_service.rb
+++ b/recipes/launchd_service.rb
@@ -18,7 +18,7 @@ end
 
 template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
   source 'com.chef.chef-client.plist.erb'
-  mode "644"
+  mode '644'
   variables(
     launchd_mode: node['chef_client']['launchd_mode'],
     client_bin: client_bin

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -17,14 +17,14 @@ dist_dir, conf_dir, env_file = value_for_platform_family(
 
 template '/etc/systemd/system/chef-client.service' do
   source 'systemd/chef-client.service.erb'
-  mode "644"
+  mode '644'
   variables(client_bin: client_bin, sysconfig_file: "/etc/#{conf_dir}/#{env_file}")
   notifies :restart, 'service[chef-client]', :delayed
 end
 
 template "/etc/#{conf_dir}/#{env_file}" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
-  mode "644"
+  mode '644'
   notifies :restart, 'service[chef-client]', :delayed
 end
 

--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -14,7 +14,7 @@ upstart_job_suffix = '.conf'
 
 template "#{upstart_job_dir}/chef-client#{upstart_job_suffix}" do
   source 'debian/init/chef-client.conf.erb'
-  mode "644"
+  mode '644'
   variables(
     client_bin: client_bin
   )

--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -41,7 +41,7 @@ template "#{node['chef_client']['conf_dir']}/client.service.rb" do
   source 'client.service.rb.erb'
   owner d_owner
   group node['root_group']
-  mode "644"
+  mode '644'
 end
 
 execute 'register-chef-service' do

--- a/templates/default/debian/init.d/chef-client.erb
+++ b/templates/default/debian/init.d/chef-client.erb
@@ -37,8 +37,8 @@ running_pid() {
   name=$2
   [ -z "$pid" ] && return 1
   [ ! -d /proc/$pid ] &&  return 1
-  cmd=`cat /proc/$pid/cmdline | tr '\000' '\n' | awk 'NR==2'`
-  [ "$cmd" != "$name" ] &&  return 1
+  cmd=`cat /proc/$pid/cmdline | tr '\000' ' '`
+  [ "$cmd" !=~ "$name" ] &&  return 1
   return 0
 }
 
@@ -203,4 +203,3 @@ case "$1" in
 esac
 
 exit 0
-

--- a/test/integration/service_bsd/service_bsd_spec.rb
+++ b/test/integration/service_bsd/service_bsd_spec.rb
@@ -1,3 +1,9 @@
 describe command('/usr/local/etc/rc.d/chef-client status | grep "chef is running"') do
   its(:exit_status) { should eq 0 }
 end
+
+describe service('chef-client') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end

--- a/test/integration/service_init/service_init_spec.rb
+++ b/test/integration/service_init/service_init_spec.rb
@@ -1,3 +1,9 @@
 describe command('ps aux | grep che[f]') do
   its(:stdout) { should match /chef-client/ }
 end
+
+describe service('chef-client') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end

--- a/test/integration/service_runit/service_runit_spec.rb
+++ b/test/integration/service_runit/service_runit_spec.rb
@@ -5,3 +5,9 @@ end
 describe file('/etc/service/chef-client/run') do
   it { should be_file }
 end
+
+describe service('chef-client') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end

--- a/test/integration/service_systemd/service_init_spec.rb
+++ b/test/integration/service_systemd/service_init_spec.rb
@@ -1,3 +1,9 @@
 describe command('ps aux | grep che[f]') do
   its(:stdout) { should match /chef-client/ }
 end
+
+describe service('chef-client') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end

--- a/test/integration/service_upstart/service_upstart_spec.rb
+++ b/test/integration/service_upstart/service_upstart_spec.rb
@@ -1,3 +1,9 @@
 describe command('ps aux | grep che[f]') do
   its(:stdout) { should match /chef-client/ }
 end
+
+describe service('chef-client') do
+  it { should be_enabled }
+  it { should be_installed }
+  it { should be_running }
+end


### PR DESCRIPTION
### Description

We can't always guarantee that the `$name` will be the second field in
the service command. (See chef/appbundler#24).

Instead, check that the command includes the desired name.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
