### PR TITLE
Fix invalid shell syntax in /etc/init.d script

### DIFF
--- a/templates/default/debian/init.d/chef-client.erb
+++ b/templates/default/debian/init.d/chef-client.erb
@@ -37,9 +37,7 @@ running_pid() {
   name=$2
   [ -z "$pid" ] && return 1
   [ ! -d /proc/$pid ] &&  return 1
-  cmd=`cat /proc/$pid/cmdline | tr '\000' ' '`
-  [ "$cmd" !=~ "$name" ] &&  return 1
-  return 0
+  cat /proc/$pid/cmdline | tr '\000' ' ' | grep -q "$name"
 }
 
 running() {


### PR DESCRIPTION
### Description

Fix invalid shell syntax that was introduced in 7.0.2.

### Issues Resolved

* Fixes #444 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Tom Duffield <tom@chef.io>