### PR TITLE
Allow customizing the chef-client service name for Debian, SUSE, RHEL, and Fedora platform families.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,21 +100,25 @@ when 'aix'
   default['chef_client']['log_dir']     = '/var/adm/chef'
 when 'debian'
   default['chef_client']['init_style']  = node['init_package']
+  default['chef_client']['svc_name']    = 'chef-client'
   default['chef_client']['run_path']    = '/var/run/chef'
   default['chef_client']['cache_path']  = '/var/cache/chef'
   default['chef_client']['backup_path'] = '/var/lib/chef'
 when 'suse'
   default['chef_client']['init_style']  = 'systemd'
+  default['chef_client']['svc_name']    = 'chef-client'
   default['chef_client']['run_path']    = '/var/run/chef'
   default['chef_client']['cache_path']  = '/var/cache/chef'
   default['chef_client']['backup_path'] = '/var/lib/chef'
 when 'rhel'
   default['chef_client']['init_style']  = node['init_package']
+  default['chef_client']['svc_name']    = 'chef-client'
   default['chef_client']['run_path']    = '/var/run/chef'
   default['chef_client']['cache_path']  = '/var/cache/chef'
   default['chef_client']['backup_path'] = '/var/lib/chef'
 when 'fedora'
   default['chef_client']['init_style']  = 'systemd'
+  default['chef_client']['svc_name']    = 'chef-client'
   default['chef_client']['run_path']    = '/var/run/chef'
   default['chef_client']['cache_path']  = '/var/cache/chef'
   default['chef_client']['backup_path'] = '/var/lib/chef'
@@ -174,9 +178,9 @@ default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil
 default['chef_client']['log_rotation']['postrotate'] =  case node['chef_client']['init_style']
                                                         when 'systemd'
-                                                          'systemctl reload chef-client.service >/dev/null || :'
+                                                          "systemctl reload #{node['chef_client']['svc_name']}.service >/dev/null || :"
                                                         when 'upstart'
-                                                          'initctl reload chef-client >/dev/null || :'
+                                                          "initctl reload #{node['chef_client']['svc_name']} >/dev/null || :"
                                                         else
-                                                          '/etc/init.d/chef-client reload >/dev/null || :'
+                                                          "/etc/init.d/#{node['chef_client']['svc_name']} reload >/dev/null || :"
                                                         end

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -42,18 +42,19 @@ dist_dir, conf_dir = value_for_platform_family(
 # let's create the service file so the :disable action doesn't fail
 case node['platform_family']
 when 'debian', 'rhel', 'fedora', 'suse'
-  template '/etc/init.d/chef-client' do
+  template "/etc/init.d/#{node['chef_client']['svc_name']}" do
     source "#{dist_dir}/init.d/chef-client.erb"
     mode '755'
     variables(client_bin: client_bin)
   end
 
-  template "/etc/#{conf_dir}/chef-client" do
+  template "/etc/#{conf_dir}/#{node['chef_client']['svc_name']}" do
     source "#{dist_dir}/#{conf_dir}/chef-client.erb"
     mode '644'
   end
 
   service 'chef-client' do
+    service_name node['chef_client']['svc_name']
     supports status: true, restart: true
     provider Chef::Provider::Service::Upstart if node['chef_client']['init_style'] == 'upstart'
     action [:disable, :stop]

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -16,20 +16,21 @@ dist_dir, conf_dir = value_for_platform_family(
   ['suse'] => %w( suse sysconfig )
 )
 
-template '/etc/init.d/chef-client' do
+template "/etc/init.d/#{node['chef_client']['svc_name']}" do
   source "#{dist_dir}/init.d/chef-client.erb"
   mode '755'
   variables client_bin: client_bin
   notifies :restart, 'service[chef-client]', :delayed
 end
 
-template "/etc/#{conf_dir}/chef-client" do
+template "/etc/#{conf_dir}/#{node['chef_client']['svc_name']}" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
   mode '644'
   notifies :restart, 'service[chef-client]', :delayed
 end
 
 service 'chef-client' do
+  service_name node['chef_client']['svc_name']
   supports status: true, restart: true
   action [:enable, :start]
 end

--- a/recipes/runit_service.rb
+++ b/recipes/runit_service.rb
@@ -3,7 +3,7 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-Chef::Log.warn("Running chef-client under the Runit init system is deprecated. Please consider running under your native init system instead.")
+Chef::Log.warn('Running chef-client under the Runit init system is deprecated. Please consider running under your native init system instead.')
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -8,27 +8,28 @@ Chef::Log.debug("Found chef-client in #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_directories
 
-dist_dir, conf_dir, env_file = value_for_platform_family(
-  ['fedora'] => ['fedora', 'sysconfig', 'chef-client'],
-  ['rhel'] => ['redhat', 'sysconfig', 'chef-client'],
-  ['suse'] => ['redhat', 'sysconfig', 'chef-client'],
-  ['debian'] => ['debian', 'default', 'chef-client']
+dist_dir, conf_dir = value_for_platform_family(
+  ['fedora'] => %w( fedora sysconfig ),
+  ['rhel'] => %w( redhat sysconfig ),
+  ['suse'] => %w( redhat sysconfig ),
+  ['debian'] => %w( debian default )
 )
 
-template '/etc/systemd/system/chef-client.service' do
+template "/etc/systemd/system/#{node['chef_client']['svc_name']}.service" do
   source 'systemd/chef-client.service.erb'
   mode '644'
-  variables(client_bin: client_bin, sysconfig_file: "/etc/#{conf_dir}/#{env_file}")
+  variables(client_bin: client_bin, sysconfig_file: "/etc/#{conf_dir}/#{node['chef_client']['svc_name']}")
   notifies :restart, 'service[chef-client]', :delayed
 end
 
-template "/etc/#{conf_dir}/#{env_file}" do
+template "/etc/#{conf_dir}/#{node['chef_client']['svc_name']}" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
   mode '644'
   notifies :restart, 'service[chef-client]', :delayed
 end
 
 service 'chef-client' do
+  service_name node['chef_client']['svc_name']
   supports status: true, restart: true
   action [:enable, :start]
 end

--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -12,7 +12,7 @@ create_directories
 upstart_job_dir = '/etc/init'
 upstart_job_suffix = '.conf'
 
-template "#{upstart_job_dir}/chef-client#{upstart_job_suffix}" do
+template "#{upstart_job_dir}/#{node['chef_client']['svc_name']}#{upstart_job_suffix}" do
   source 'debian/init/chef-client.conf.erb'
   mode '644'
   variables(
@@ -22,6 +22,7 @@ template "#{upstart_job_dir}/chef-client#{upstart_job_suffix}" do
 end
 
 service 'chef-client' do
+  service_name node['chef_client']['svc_name']
   provider Chef::Provider::Service::Upstart
   action [:enable, :start]
 end

--- a/templates/default/debian/init.d/chef-client.erb
+++ b/templates/default/debian/init.d/chef-client.erb
@@ -1,24 +1,24 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:           chef-client
+# Provides:           <%= node["chef_client"]["svc_name"] %>
 # Required-Start:     $remote_fs $network
 # Required-Stop:      $remote_fs $network
 # Default-Start:      2 3 4 5
 # Default-Stop:       0 1 6
-# Short-Description:  Start a chef-client.
+# Short-Description:  Start a <%= node["chef_client"]["svc_name"] %>.
 ### END INIT INFO
 #
 # Copyright (c) 2009-2010 Chef Software, Inc, <legal@chef.io>
 #
-# chef-client         Startup script for chef-client.
+# <%= node["chef_client"]["svc_name"] %>         Startup script for <%= node["chef_client"]["svc_name"] %>.
 # chkconfig: - 99 02
-# description: starts up chef-client in daemon mode.
+# description: starts up <%= node["chef_client"]["svc_name"] %> in daemon mode.
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=<%= @client_bin %>
-NAME=chef-client
-DESC=chef-client
-PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
+NAME=<%= node["chef_client"]["svc_name"] %>
+DESC=<%= node["chef_client"]["svc_name"] %>
+PIDFILE=<%= node["chef_client"]["run_path"] %>/<%= if node["chef_client"]["svc_name"] == 'chef-client' then 'client' else node["chef_client"]["svc_name"] end %>.pid
 
 test -x $DAEMON || exit 1
 

--- a/templates/default/debian/init/chef-client.conf.erb
+++ b/templates/default/debian/init/chef-client.conf.erb
@@ -1,4 +1,4 @@
-# chef-client - Chef Configuration Management Client
+# <%= node["chef_client"]["svc_name"] %> - Chef Configuration Management Client
 #
 # Chef Client provides the Chef configuration management daemon
 

--- a/templates/default/fedora/sysconfig/chef-client.erb
+++ b/templates/default/fedora/sysconfig/chef-client.erb
@@ -1,8 +1,8 @@
-# Configuration file for the chef-client service
+# Configuration file for the <%= node["chef_client"]["svc_name"] %> service
 
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
-PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
-#LOCKFILE=/var/lock/subsys/chef-client
+PIDFILE=<%= node["chef_client"]["run_path"] %>/<%= if node["chef_client"]["svc_name"] == 'chef-client' then 'client' else node["chef_client"]["svc_name"] end %>.pid
+#LOCKFILE=/var/lock/subsys/<%= node["chef_client"]["svc_name"] %>
 # Sleep interval between runs.
 # This value is in seconds.
 INTERVAL=<%= node["chef_client"]["interval"] %>

--- a/templates/default/redhat/init.d/chef-client.erb
+++ b/templates/default/redhat/init.d/chef-client.erb
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
-# chef-client Startup script for the Chef client
+# <%= node["chef_client"]["svc_name"] %> Startup script for the Chef client
 #
 # chkconfig: - 98 02
 # description: Client component of the Chef systems integration framework.
 
 ### BEGIN INIT INFO
-# Provides: chef-client
+# Provides: <%= node["chef_client"]["svc_name"] %>
 # Required-Start: $local_fs $network $remote_fs
 # Required-Stop: $local_fs $network $remote_fs
 # Should-Start: $named $time
@@ -19,7 +19,7 @@
 . /etc/init.d/functions
 
 exec="<%= @client_bin %>"
-prog="chef-client"
+prog="<%= node["chef_client"]["svc_name"] %>"
 
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
 

--- a/templates/default/redhat/sysconfig/chef-client.erb
+++ b/templates/default/redhat/sysconfig/chef-client.erb
@@ -1,8 +1,8 @@
-# Configuration file for the chef-client service
+# Configuration file for the <%= node["chef_client"]["svc_name"] %> service
 
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
-PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
-#LOCKFILE=/var/lock/subsys/chef-client
+PIDFILE=<%= node["chef_client"]["run_path"] %>/<%= if node["chef_client"]["svc_name"] == 'chef-client' then 'client' else node["chef_client"]["svc_name"] end %>.pid
+#LOCKFILE=/var/lock/subsys/<%= node["chef_client"]["svc_name"] %>
 # Sleep interval between runs.
 # This value is in seconds.
 INTERVAL=<%= node["chef_client"]["interval"] %>

--- a/templates/default/suse/init.d/chef-client.erb
+++ b/templates/default/suse/init.d/chef-client.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:          chef-client
+# Provides:          <%= node["chef_client"]["svc_name"] %>
 # Required-Start:    $syslog $remote_fs
 # Should-Start:      $time
 # Required-Stop:     $syslog $remote_fs
@@ -20,8 +20,8 @@ test -x $CHEF_CLIENT || { echo "$CHEF_CLIENT not installed";
 PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
 
 # Read sysconfig
-if [ -f "/etc/sysconfig/chef-client" ]; then
-    . /etc/sysconfig/chef-client
+if [ -f "/etc/sysconfig/<%= node["chef_client"]["svc_name"] %>" ]; then
+    . /etc/sysconfig/<%= node["chef_client"]["svc_name"] %>
 fi
 
 CONFIG=${CONFIG-<%= node["chef_client"]["conf_dir"] %>/client.rb}
@@ -72,7 +72,7 @@ rc_reset
 
 case "$1" in
     start)
-        echo -n "Starting chef-client "
+        echo -n "Starting <%= node["chef_client"]["svc_name"] %> "
         ## Start daemon with startproc(8). If this fails
         ## the return value is set appropriately by startproc.
         /sbin/startproc -p $PIDFILE $CHEF_CLIENT -d -c "$CONFIG" -P "$PIDFILE" -i "$INTERVAL" -s "$SPLAY" "$OPTIONS"
@@ -81,7 +81,7 @@ case "$1" in
         rc_status -v
         ;;
     stop)
-        echo -n "Shutting down chef-client "
+        echo -n "Shutting down <%= node["chef_client"]["svc_name"] %> "
         ## Stop daemon with killproc(8) and if this fails
         ## killproc sets the return value according to LSB.
 
@@ -116,7 +116,7 @@ case "$1" in
         rc_status
         ;;
     status)
-        echo -n "Checking for service chef-client "
+        echo -n "Checking for service <%= node["chef_client"]["svc_name"] %> "
         ## Check status with checkproc(8), if process is running
         ## checkproc will return with exit status 0.
 

--- a/templates/default/suse/sysconfig/chef-client.erb
+++ b/templates/default/suse/sysconfig/chef-client.erb
@@ -1,8 +1,8 @@
-# Configuration file for the chef-client service
+# Configuration file for the <%= node["chef_client"]["svc_name"] %> service
 
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
-PIDFILE=<%= node["chef_client"]["run_path"] %>/client.pid
-#LOCKFILE=/var/lock/subsys/chef-client
+PIDFILE=<%= node["chef_client"]["run_path"] %>/<%= if node["chef_client"]["svc_name"] == 'chef-client' then 'client' else node["chef_client"]["svc_name"] end %>.pid
+#LOCKFILE=/var/lock/subsys/<%= node["chef_client"]["svc_name"] %>
 # Sleep interval between runs.
 # This value is in seconds.
 INTERVAL=<%= node["chef_client"]["interval"] %>


### PR DESCRIPTION
### Description

Expands the use of the 'svc_name' attribute, previously only used in the 'src_service' recipe, to Debian, SUSE, RHEL, and Fedora.

### Issues Resolved

Feature expansion. Fix to cookstyle quoting error in runit_service recipe.

### Check List

- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
