### PR TITLE
Task Creds should be in an encrypted data bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['task']['user']` - The user the scheduled task will run as, defaults to `'SYSTEM'`.
 - `node['chef_client']['task']['password']` - The password for the user the scheduled task will run as, defaults to `nil` because the default user, `'SYSTEM'`, does not need a password.
 
+Optionally, for better security, task user and password can be defined in a data bag
+- `node['chef_client']['data_bag']['name']` - = The data bag name, defaults to `'chef_client'`.
+- `node['chef_client']['data_bag']['config_item']` - The daat bag item, defaults to `'config'`.
+```json
+{
+  "task": {
+    "user": "scheduled_task_username",
+    "password": "scheduled_task_password"
+  },
+  "id": "config"
+}
+```
+
 The following attributes are set on a per-platform basis, see the `attributes/default.rb` file for default values.
 
 - `node['chef_client']['init_style']` - Sets up the client service based on the style of init system to use. Default is based on platform and falls back to `'none'`. See [service recipes](#service-recipes).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,10 @@ default['chef_client']['task']['frequency_modifier'] = node['chef_client']['inte
 default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for none system users
 
+# Configuration inside data bag
+default['chef_client']['data_bag']['name'] = 'chef_client'
+default['chef_client']['data_bag']['config_item'] = 'config'
+
 default['chef_client']['load_gems'] = {}
 
 # If set to false, changes in the `client.rb` template won't trigger a reload

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -100,6 +100,17 @@ module Opscode
           raise "Could not locate the chef-client bin in any known path. Please set the proper path by overriding the node['chef_client']['bin'] attribute."
         end
       end
+
+      def self.data_bag_item(data_bag_name, data_bag_item, missing_ok=false)
+
+              Chef::EncryptedDataBagItem.load(data_bag_name, data_bag_item).to_hash.delete_if { |key, value| key == 'id' }
+
+            rescue Chef::Exceptions::ValidationFailed,
+                  Chef::Exceptions::InvalidDataBagPath,
+                  Net::HTTPServerException => error
+                     missing_ok ? nil : raise(error)
+                   end
+
     end
   end
 end


### PR DESCRIPTION
Allow optional retrieval of config settings from encrypted data bag, specifically for scheduled task user and password (which should not be in clear text in node attributes.)

Signed-off-by: smcavallo <steve.cavallo@sonian.net>

### Description

Allow optional retrieval of config settings from encrypted data bag, specifically for scheduled task user and password (which should not be in clear text in node attributes.)

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
   The windows boxes in the kitchen tests are marked private.  I do have tests which include adding an encrypted data bag to the test suites, if required.  The new functionality did not break any existing tests.
* I have tested this locally with custom windows images
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
