### PR TITLE
skip validation.pem deletion in test-kitchen + chef-zero

### DIFF
--- a/recipes/delete_validation.rb
+++ b/recipes/delete_validation.rb
@@ -21,9 +21,9 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-# Don't do anything run running as solo. This can happen when using ChefSpec or
+# Don't do anything run running as solo or zero in Test-Kitchen. This can happen when using ChefSpec or
 # Test Kitchen.
-if Chef::Config[:solo]
+if Chef::Config[:solo] || (Chef::Config[:chef_server_url].include?('localhost') && ENV['TEST_KITCHEN'])
   if !ENV['TEST_KITCHEN'] && !defined?(ChefSpec)
     Chef::Log.info('[chef-client::delete_validation] Skipping validation ' \
       'delete because we are running under chef-solo')


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tm@intility.no>

### Description

This change prevents delete_validation from running when using chef-zero in test-kitchen. validation.pem is recreated on every converge in test-kitchen.



### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
