### PR TITLE
node_name is better than fqdn

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -5,7 +5,7 @@
 # Cookbook::  chef-client
 # Recipe:: cron
 #
-# Copyright:: 2009-2016, Chef Software, Inc.
+# Copyright:: 2009-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ end
 
 # Generate a uniformly distributed unique number to sleep.
 if node['chef_client']['splay'].to_i > 0
-  checksum   = Digest::MD5.hexdigest(node['fqdn'] || 'unknown-hostname')
+  checksum   = Digest::MD5.hexdigest(node['node_name'])
   sleep_time = checksum.to_s.hex % node['chef_client']['splay'].to_i
 else
   sleep_time = nil


### PR DESCRIPTION
fqdn can be nil and the nil behavior this replaces is horrible

node_name has to be unique or nodes will be scribbling over the
same entries in the database.  also node_name has to be not-nil or
else chef-client itself throws an exception very early, so we
can now ignore that case.
