### PR TITLE
Support node['chef_client']['log_file'] usage in recipes and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef-client cookbook.
 
+## 7.3.0 (2017-03-13)
+- Use `node['chef_client']['log_file']` in recipes rather than hard-coded `client.log`
+- Add `node['chef_client']['log_file']` information to README
+
 ## 7.2.0 (2017-02-24)
 
 - Add a chef_client_scheduled_task custom resource. This is is used by the 'task' recipe, but can also be used directly in a wrapper cookbook. Why would I want to use this? Well when used in a wrapper cookbook you can directly pass the username/password to the resource, thus avoiding node attributes. This means you can store your credentials in any secure method you want.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following attributes affect the behavior of the chef-client program when run
 
 - `node['chef_client']['interval']` - Sets `Chef::Config[:interval]` via command-line option for number of seconds between chef-client daemon runs. Default 1800.
 - `node['chef_client']['splay']` - Sets `Chef::Config[:splay]` via command-line option for a random amount of seconds to add to interval. Default 300.
+- `node['chef_client']['log_file']` - Sets the file name used to store chef-client logs. Default "client.log".
 - `node['chef_client']['log_dir']` - Sets directory used to store chef-client logs. Default "/var/log/chef".
 - `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.
 - `node['chef_client']['log_rotation']['prerotate']` - Set prerotate action for chef-client logrotation. Default to `nil`.

--- a/recipes/src_service.rb
+++ b/recipes/src_service.rb
@@ -31,7 +31,7 @@ node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 
 execute "install #{node['chef_client']['svc_name']} in SRC" do
-  command "mkssys -s #{node['chef_client']['svc_name']} -p #{node['chef_client']['bin']} -u root -S -n 15 -f 9 -o #{node['chef_client']['log_dir']}/client.log -e #{node['chef_client']['log_dir']}/client.log -a '-i #{node['chef_client']['interval']} -s #{node['chef_client']['splay']}'"
+  command "mkssys -s #{node['chef_client']['svc_name']} -p #{node['chef_client']['bin']} -u root -S -n 15 -f 9 -o #{node['chef_client']['log_dir']}/#{node['chef_client']['log_file']} -e #{node['chef_client']['log_dir']}/#{node['chef_client']['log_file']} -a '-i #{node['chef_client']['interval']} -s #{node['chef_client']['splay']}'"
   not_if "lssrc -s #{node['chef_client']['svc_name']}"
   action :run
 end

--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -34,7 +34,7 @@ create_chef_directories
 d_owner = root_owner
 install_command = "chef-service-manager -a install -c #{File.join(node['chef_client']['conf_dir'], 'client.service.rb')}"
 if Chef::VERSION <= '12.5.1'
-  install_command << " -L #{File.join(node['chef_client']['log_dir'], 'client.log')}"
+  install_command << " -L #{File.join(node['chef_client']['log_dir'], node['chef_client']['log_file'])}"
 end
 
 template "#{node['chef_client']['conf_dir']}/client.service.rb" do

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -35,7 +35,7 @@ action :add do
 
   # Build command line to pass to cmd.exe
   client_cmd = new_resource.chef_binary_path
-  client_cmd << " -L #{::File.join(new_resource.log_directory, 'client.log')}"
+  client_cmd << " -L #{::File.join(new_resource.log_directory, node['chef_client']['log_file'])}"
   client_cmd << " -c #{::File.join(new_resource.config_directory, 'client.rb')}"
   client_cmd << " -s #{new_resource.splay}"
 

--- a/templates/default/com.chef.chef-client.plist.erb
+++ b/templates/default/com.chef.chef-client.plist.erb
@@ -26,7 +26,7 @@
   <true/>
 <%- end %>
   <key>StandardOutPath</key>
-  <string><%= node["chef_client"]["log_dir"] %>/client.log</string>
+  <string><%= node["chef_client"]["log_dir"] %>/<%= node['chef_client']['log_file'] %></string>
 </dict>
 
 </plist>

--- a/templates/windows/client.service.rb.erb
+++ b/templates/windows/client.service.rb.erb
@@ -2,7 +2,7 @@ if File.exists?(%q|<%= node["chef_client"]["conf_dir"] %>/client.rb|)
    Chef::Config.from_file(%q|<%= node["chef_client"]["conf_dir"] %>/client.rb|)
 end
 
-log_location "<%= File.join(node['chef_client']['log_dir'], 'client.log') %>"
+log_location "<%= File.join(node['chef_client']['log_dir'], node['chef_client']['log_file']) %>"
 
 <% unless node["chef_client"]["interval"].nil? -%>
 interval <%= node["chef_client"]["interval"] %>


### PR DESCRIPTION
### Description

There is an attribute `log_file` that is sporadically used (once in config.rb) for log rotation whereas the name of the logfile is otherwise hardcoded in various places. This PR makes the use of the attribute consistent across the whole cookbook

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

PR reviewers, note that I am unable to run the test suite because I'm unable to install vagrant.