### PR TITLE
Make chef_client_scheduled_task idempotent

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -45,7 +45,7 @@ action :add do
   start_time = new_resource.frequency == 'minute' ? (Time.now + 60 * new_resource.frequency_modifier).strftime('%H:%M') : nil
   windows_task 'chef-client' do
     run_level :highest
-    command "cmd /c \"#{client_cmd} ^> NUL 2^>^&1\""
+    command "cmd /c \"#{client_cmd}\""
 
     user               new_resource.user
     password           new_resource.password


### PR DESCRIPTION
### Description
Remove command redirections from chef-client command as `windows_task`
doesn't support them, as per https://github.com/chef-cookbooks/windows/issues/426

### Issues Resolved

https://github.com/chef-cookbooks/chef-client/issues/460
