### PR TITLE
Fix nil attribute in cron recipe

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -87,7 +87,7 @@ end
 
 # Generate a uniformly distributed unique number to sleep.
 if node['chef_client']['splay'].to_i > 0
-  checksum   = Digest::MD5.hexdigest(node['node_name'])
+  checksum   = Digest::MD5.hexdigest(node['fqdn'])
   sleep_time = checksum.to_s.hex % node['chef_client']['splay'].to_i
 else
   sleep_time = nil

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -87,8 +87,8 @@ end
 
 # Generate a uniformly distributed unique number to sleep.
 if node['chef_client']['splay'].to_i > 0
-  checksum   = Digest::MD5.hexdigest(node['fqdn'])
-  sleep_time = checksum.to_s.hex % node['chef_client']['splay'].to_i
+  seed = node['shard_seed'] || Digest::MD5.hexdigest(node.name).to_s.hex
+  sleep_time = seed % node['chef_client']['splay'].to_i
 else
   sleep_time = nil
 end


### PR DESCRIPTION
### Description

node['node_name'] is not a valid ohai attribute, and does not pass unit tests.  This change switches to node['fqdn'] to avoid a nil attribute.

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
