### PR TITLE
Fix lint errors.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -25,7 +25,7 @@ recipe 'chef-client::windows_service', 'Configures chef-client as a service on W
 end
 
 # Runit is necessary if runit is being used, but is not explicitly required
-suggests 'runit'
+suggests 'runit' # ~FC052
 
 depends 'cron', '>= 1.7.0'
 depends 'logrotate', '>= 1.9.0'

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -18,6 +18,7 @@
 #
 
 provides :chef_client_scheduled_task
+default_action :add
 
 property :user, String, required: true
 property :password, String


### PR DESCRIPTION
### Description

There are two lint errors when running foodcritic.  The scheduled_task resource does not specify a default action, and the metadata uses a suggests keyword (FC016 and FC052 respectively).

You can see these errors by running the following command from the cookbook directory:
`foodcritic -f any -t any .`

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
