### PR TITLE
Disable chef-client service if it exists

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -87,7 +87,7 @@ end
 
 # Generate a uniformly distributed unique number to sleep.
 if node['chef_client']['splay'].to_i > 0
-  checksum   = Digest::MD5.hexdigest(node['node_name'])
+  checksum   = Digest::MD5.hexdigest(node['hostname'])
   sleep_time = checksum.to_s.hex % node['chef_client']['splay'].to_i
 else
   sleep_time = nil

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -18,6 +18,12 @@
 # limitations under the License.
 #
 
+windows_service 'chef-client' do
+  startup_type :disabled
+  action :configure_startup
+  only_if { ::Win32::Service.exists?('chef-client') }
+end
+
 chef_client_scheduled_task 'Chef Client' do
   user node['chef_client']['task']['user']
   password node['chef_client']['task']['password']


### PR DESCRIPTION
### Description

If using a scheduled task then the service should be disabled if it exists.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
