### PR TITLE
Properly start systemd timer when necessary

### DIFF
--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -68,8 +68,8 @@ systemd_unit 'chef-client.timer' do
   EOH
   enabled timer
   if timer
-    action [:create, :enable]
+    action [:create, :enable, :start]
   else
-    action [:disable, :delete]
+    action [:stop, :disable, :delete]
   end
 end


### PR DESCRIPTION
Otherwise it requires a reboot of the node to activate the timer.

Also don't enable the service when using timer.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
