### PR TITLE
Allow control of systemd restart setting through attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['reload_config']` - If true, reload Chef config of current Chef run when `client.rb` template changes (defaults to true)
 - `node['chef_client']['daemon_options']` - An array of additional options to pass to the chef-client service, empty by default, and must be an array if specified.
 - `node['chef_client']['systemd']['timer']` - If true, uses systemd timer to run chef frequently instead of chef-client daemon mode (defaults to false). This only works on platforms where systemd is installed and used.
+- `node['chef_client']['systemd']['restart']` - The string to use for systemd `Restart=` value when not running as a timer. Defaults to `on-failure`. Other possible options: `always, no, on-success, on-failure, on-abnormal, on-watchdog, on-abort`.
 - `node['chef_client']['task']['frequency']` - Frequency with which to run the `chef-client` scheduled task (e.g., `'hourly'`, `'daily'`, etc.) Default is `'minute'`.
 - `node['chef_client']['task']['frequency_modifier']` - Numeric value to go with the scheduled task frequency. Default is `node['chef_client']['interval'].to_i / 60`
 - `node['chef_client']['task']['start_time']` - The start time for the task in `HH:mm` format. If the `frequency` is `minute` default start time will be `Time.now` plus the `frequency_modifier` number of minutes.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,8 @@ default['chef_client']['cron'] = {
 
 # Configuration for chef-client::systemd_service recipe
 default['chef_client']['systemd']['timer'] = false
+# Restart mode when not running as a timer
+default['chef_client']['systemd']['restart'] = 'on-failure'
 
 # Configuration for Windows scheduled task
 default['chef_client']['task']['frequency'] = 'minute'

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -32,7 +32,7 @@ template '/etc/systemd/system/chef-client.service' do
     sysconfig_file: "/etc/#{conf_dir}/#{env_file}",
     type: (timer ? 'oneshot' : 'simple'),
     exec_options: exec_options,
-    restart_mode: (timer ? nil : 'on-failure')
+    restart_mode: (timer ? nil : node['chef_client']['systemd']['restart'])
   )
   notifies :restart, 'service[chef-client]', :delayed unless node['chef_client']['systemd']['timer']
 end


### PR DESCRIPTION
Signed-off-by: Matt Kulka <mkulka@parchment.com>

### Description

`chef-client` is not currently compatible with `chef_client_updater` because of issue https://github.com/chef-cookbooks/chef_client_updater/issues/6. Allowing the restart setting in the chef-client systemd service to be "always" would workaround the issue and restart chef-client as a service when `chef_client_updater` sends it the TERM signal.

### Issues Resolved

https://github.com/chef-cookbooks/chef_client_updater/issues/6

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>