### PR TITLE
Systemd timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['reload_config']` - If true, reload Chef config of current Chef run when `client.rb` template changes (defaults to true)
 - `node['chef_client']['daemon_options']` - An array of additional options to pass to the chef-client service, empty by default, and must be an array if specified.
 - `node['chef_client']['systemd']['timer']` - If true, uses systemd timer to run chef frequently instead of chef-client daemon mode (defaults to false). This only works on platforms where systemd is installed and used.
+- `node['chef_client']['systemd']['timeout']` - If configured, sets the systemd timeout. This might be useful to avoid stalled chef runs in the systemd timer setup.
 - `node['chef_client']['systemd']['restart']` - The string to use for systemd `Restart=` value when not running as a timer. Defaults to `always`. Other possible options: `no, on-success, on-failure, on-abnormal, on-watchdog, on-abort`.
 - `node['chef_client']['task']['frequency']` - Frequency with which to run the `chef-client` scheduled task (e.g., `'hourly'`, `'daily'`, etc.) Default is `'minute'`.
 - `node['chef_client']['task']['frequency_modifier']` - Numeric value to go with the scheduled task frequency. Default is `node['chef_client']['interval'].to_i / 60`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -62,6 +62,8 @@ default['chef_client']['cron'] = {
 
 # Configuration for chef-client::systemd_service recipe
 default['chef_client']['systemd']['timer'] = false
+# Systemd timeout. Might be usefull for timer setups to avoid stalled chef runs
+default['chef_client']['systemd']['timeout'] = false
 # Restart mode when not running as a timer
 default['chef_client']['systemd']['restart'] = 'always'
 

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -42,6 +42,11 @@ service_unit_content = {
 
 service_unit_content['Service'].delete('Restart') if timer
 
+if node['chef_client']['systemd']['timeout']
+  service_unit_content['Service']['TimeoutSec'] =
+    node['chef_client']['systemd']['timeout']
+end
+
 systemd_unit 'chef-client.service' do
   content service_unit_content
   action :create
@@ -51,7 +56,7 @@ end
 template "/etc/#{conf_dir}/#{env_file}" do
   source "#{dist_dir}/#{conf_dir}/chef-client.erb"
   mode '644'
-  notifies :restart, 'service[chef-client]', :delayed unless node['chef_client']['systemd']['timer']
+  notifies :restart, 'service[chef-client]', :delayed unless timer
 end
 
 service 'chef-client' do


### PR DESCRIPTION
### Description
It can be used in the systemd timer setup to avoid stalled chef runs.
E.g. chef run gets stalled sometimes if used on the notebook and it gets
moved to another network during the run. The stalled chef process does not allow
the execution of any other chef runs.
Using the systemd timeout we can kill this stalled chef runs via systemd.

### Issues Resolved

Can be seen as solution for https://github.com/chef-cookbooks/chef-client/issues/320, but for systemd timer setup instead of cron.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
