### PR TITLE
Bugfix: do not enable the service if timer is used

### DIFF
--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -43,12 +43,13 @@ template "/etc/#{conf_dir}/#{env_file}" do
   notifies :restart, 'service[chef-client]', :delayed unless node['chef_client']['systemd']['timer']
 end
 
-service_actions = [:enable]
-service_actions << :start unless node['chef_client']['systemd']['timer']
-
 service 'chef-client' do
   supports status: true, restart: true
-  action service_actions
+  if timer
+    action [:disable, :stop]
+  else
+    action [:enable, :start]
+  end
 end
 
 systemd_unit 'chef-client.timer' do


### PR DESCRIPTION
### Description

If the systemd service is controlled by timer, we should not enable
the service in such situation but only the timer.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
