### PR TITLE
Fixes #476

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -34,7 +34,7 @@ action :add do
   create_chef_directories
 
   # Build command line to pass to cmd.exe
-  client_cmd = new_resource.chef_binary_path
+  client_cmd = new_resource.chef_binary_path.dup
   client_cmd << " -L #{::File.join(new_resource.log_directory, 'client.log')}"
   client_cmd << " -c #{::File.join(new_resource.config_directory, 'client.rb')}"
   client_cmd << " -s #{new_resource.splay}"


### PR DESCRIPTION
Signed-off-by: Stephen Hoekstra <stephenhoekstra@gmail.com>

### Description

Fixes `chef_client_scheduled_task` when using Chef 13.  

Tested locally with kitchen using a 2012R2 vagrant box and Chef 13.0.118.

### Issues Resolved

#476

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
