### PR TITLE
Add ability to set daemonized SSL trust store

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.
 - `node['chef_client']['conf_dir']` - Sets directory used via command-line option to a location where chef-client search for the client config file . Default "/etc/chef".
 - `node['chef_client']['bin']` - Sets the full path to the `chef-client` binary. Mainly used to set a specific path if multiple versions of chef-client exist on a system or the bin has been installed in a non-sane path. Default "/usr/bin/chef-client".
+- `node['chef_client']['ca_cert_path']` - Sets the full path to the PEM-encoded certificate trust store used by `chef-client` when daemonized. If not set, [default values](https://docs.chef.io/chef_client_security.html#ssl-cert-file) are used.
 - `node['chef_client']['cron']['minute']` - The minute that chef-client will run as a cron task. See [cron recipe](#cron)
 - `node['chef_client']['cron']['hour']` - The hour that chef-client will run as a cron task. See [cron recipe](#cron)
 - `node['chef_client']['cron']['weekday']` - The weekday that chef-client will run as a cron task. See [cron recipe](#cron)

--- a/templates/default/debian/init/chef-client.conf.erb
+++ b/templates/default/debian/init/chef-client.conf.erb
@@ -19,5 +19,11 @@ script
         . /etc/default/locale
         export LANG LANGUAGE LC_MESSAGES LC_ALL
     fi
+
+    <% if node["chef_client"]["ca_cert_path"] %>
+    SSL_CERT_FILE="<%= node["chef_client"]["ca_cert_path"] %>"
+    export SSL_CERT_FILE
+
+    <% end %>
     exec <%= @client_bin %> -i <%= node["chef_client"]["interval"] %> -s <%= node["chef_client"]["splay"] %> <%= node["chef_client"]["daemon_options"].join(' ') %>
 end script

--- a/templates/default/fedora/sysconfig/chef-client.erb
+++ b/templates/default/fedora/sysconfig/chef-client.erb
@@ -12,3 +12,7 @@ INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>
 # Any additional chef-client options.
 OPTIONS="<%= node["chef_client"]["daemon_options"].join(' ') %>"
+<% if node["chef_client"]["ca_cert_path"] %>
+SSL_CERT_FILE="<%= node["chef_client"]["ca_cert_path"] %>"
+export SSL_CERT_FILE
+<% end %>

--- a/templates/default/redhat/sysconfig/chef-client.erb
+++ b/templates/default/redhat/sysconfig/chef-client.erb
@@ -12,3 +12,6 @@ INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>
 # Any additional chef-client options.
 OPTIONS="<%= node["chef_client"]["daemon_options"].join(' ') %>"
+<% if node["chef_client"]["ca_cert_path"] %>
+export SSL_CERT_FILE="<%= node["chef_client"]["ca_cert_path"] %>"
+<% end %>

--- a/templates/default/solaris/manifest-5.11.xml.erb
+++ b/templates/default/solaris/manifest-5.11.xml.erb
@@ -59,11 +59,16 @@
                 name='start'
                 exec='<%= node['chef_client']['method_dir'] %>/chef-client %m'
                 timeout_seconds='60'>
-                <% if node['chef_client']['locale'] %>
+                <% if node['chef_client']['locale'] || node["chef_client"]["ca_cert_path"] %>
                 <method_context>
                         <method_environment>
+                                <% if node['chef_client']['locale'] %>
                                 <envvar name="LANG" value="<%= node['chef_client']['locale'] %>"/>
                                 <envvar name="LC_ALL" value="<%= node['chef_client']['locale'] %>"/>
+                                <% end %>
+                                <% if node["chef_client"]["ca_cert_path"] %>
+                                <envvar name="SSL_CERT_FILE" value="<%= node["chef_client"]["ca_cert_path"] %>"/>
+                                <% end %>
                         </method_environment>
                 </method_context>
                 <% end %>

--- a/templates/default/solaris/manifest.xml.erb
+++ b/templates/default/solaris/manifest.xml.erb
@@ -59,11 +59,16 @@
                 name='start'
                 exec='<%= node['chef_client']['method_dir'] %>/chef-client %m'
                 timeout_seconds='60'>
-                <% if node['chef_client']['locale'] %>
+                <% if node['chef_client']['locale'] || node["chef_client"]["ca_cert_path"] %>
                 <method_context>
                         <method_environment>
+                                <% if node['chef_client']['locale'] %>
                                 <envvar name="LANG" value="<%= node['chef_client']['locale'] %>"/>
                                 <envvar name="LC_ALL" value="<%= node['chef_client']['locale'] %>"/>
+                                <% end %>
+                                <% if node["chef_client"]["ca_cert_path"] %>
+                                <envvar name="SSL_CERT_FILE" value="<%= node["chef_client"]["ca_cert_path"] %>"/>
+                                <% end %>
                         </method_environment>
                 </method_context>
                 <% end %>

--- a/templates/default/suse/sysconfig/chef-client.erb
+++ b/templates/default/suse/sysconfig/chef-client.erb
@@ -12,3 +12,7 @@ INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>
 # Any additional chef-client options.
 OPTIONS="<%= node["chef_client"]["daemon_options"].join(' ') %>"
+<% if node["chef_client"]["ca_cert_path"] %>
+SSL_CERT_FILE="<%= node["chef_client"]["ca_cert_path"] %>"
+export SSL_CERT_FILE
+<% end %>

--- a/templates/freebsd/chef-client.erb
+++ b/templates/freebsd/chef-client.erb
@@ -6,6 +6,11 @@
 
 . /etc/rc.subr
 
+<% if node["chef_client"]["ca_cert_path"] %>
+SSL_CERT_FILE="<%= node["chef_client"]["ca_cert_path"] %>"
+export SSL_CERT_FILE
+<% end %>
+
 name="chef"
 pidfile="<%= node["chef_client"]["run_path"] %>/${name}.pid"
 command="<%= @client_bin %>"


### PR DESCRIPTION
Signed-off-by: Daniel Ruggeri <druggeri@primary.net>

### Description

Add ability to set the SSL_CERT_FILE environment variable for daemonized clients. When not configured, no behavior changes. NOTE - this was not done for Windows clients as I'm not sure it's possible to do so.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
  - I'm unable to run the test suite for this cookbook because I do not have vagrant. However, I've run this and tested it against OEL (RHEL derivative)
- [ ] New functionality includes testing.
  - Could use help with this as I'm unable to execute the test suite
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
