### PR TITLE
Fix exception when log_level is already a symbol

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -12,7 +12,7 @@ end
   <% next if %w{ node_name exception_handlers report_handlers start_handlers http_proxy https_proxy no_proxy }.include?(option) -%>
   <% case option -%>
   <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
-<%= option %> <%= @chef_config[option].gsub(/^:/, '').to_sym.inspect %>
+<%= option %> <%= @chef_config[option].to_s.gsub(/^:/, '').to_sym.inspect %>
   <% when 'log_location' -%>
   <%   if @chef_config[option].instance_of? String -%>
 <%= option %> <%= @chef_config[option] == 'STDOUT' ? 'STDOUT' : @chef_config[option].inspect %>


### PR DESCRIPTION
Signed-off-by: joe.nuspl <nuspl@nvwls.com>

### Description

Fix exception when `log_level` is already a symbol

### Issues Resolved

https://github.com/chef-cookbooks/chef-client/issues/516

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
