### PR TITLE
Fix loading of the solaris service config on Chef 13

### DIFF
--- a/recipes/smf_service.rb
+++ b/recipes/smf_service.rb
@@ -35,16 +35,16 @@ template(local_path + 'chef-client.xml') do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :run, 'execute[load chef-client manifest]', :immediately
 end
 
 execute 'load chef-client manifest' do
   action :nothing
-  command "svccfg import #{local_path}chef-client.xml"
+  command "/usr/sbin/svccfg import #{local_path}chef-client.xml"
   notifies :restart, 'service[chef-client]'
 end
 
 service 'chef-client' do
   action [:enable, :start]
   provider Chef::Provider::Service::Solaris
+  notifies :run, 'execute[load chef-client manifest]', :before
 end


### PR DESCRIPTION
2 problems here:

- in Chef 13 we don't add /usr/sbin to the path anymore so we can't find
svcfg
- if the svccfg execute fails we never run it again since it's notified
after the template. This means every chef-client run after this fails.

Signed-off-by: Tim Smith <tsmith@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
