### PR TITLE
Fix SUSE init template to use the correct node attribute

### DIFF
--- a/templates/default/suse/init.d/chef-client.erb
+++ b/templates/default/suse/init.d/chef-client.erb
@@ -25,7 +25,7 @@ if [ -f "/etc/sysconfig/chef-client" ]; then
 fi
 
 CONFIG=${CONFIG-<%= node["chef_client"]["conf_dir"] %>/client.rb}
-PIDFILE=${PIDFILE-<%= node["chef_client"]["run_dir"] %>/client.pid}
+PIDFILE=${PIDFILE-<%= node["chef_client"]["run_path"] %>/client.pid}
 LOCKFILE=${LOCKFILE-/var/lock/subsys/chef-client}
 INTERVAL=${INTERVAL-<%= node["chef_client"]["interval"] %>}
 SPLAY=${SPLAY-<%= node["chef_client"]["splay"] %>}


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


@chef-cookbooks/ben-team 