### PR TITLE
Properly escape the command in the scheduled_task resource

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -45,7 +45,7 @@ action :add do
 
   windows_task 'chef-client' do
     run_level :highest
-    command "cmd /c \"#{client_cmd}\""
+    command "cmd /c \'#{client_cmd}\'"
     user               new_resource.user
     password           new_resource.password
     frequency          new_resource.frequency.to_sym


### PR DESCRIPTION
…e escaped attributes

Signed-off-by: Scott Hain <shain@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>


This is to avoid situations like this:
```             Mixlib::ShellOut::ShellCommandFailed
             ------------------------------------
             Expected process to exit with [0], but received '-2147467259'
             ---- Begin output of schtasks /CREATE /TN "chef-client" /F /SC "minute" /MO "30" /RU "SYSTEM" /RL "HIGHEST" /TR "cmd /c "C:\opscode\chef\bin\chef-client.bat -L C:/chef/log/client.log -c C:/chef/client.rb -s 60" "  ----
             STDOUT:
             STDERR: ERROR: Invalid argument/option - '-L'.

             Type "SCHTASKS /CREATE /?" for usage.
             ---- End output of schtasks /CREATE /TN "chef-client" /F /SC "minute" /MO "30" /RU "SYSTEM" /RL "HIGHEST" /TR "cmd /c "C:\opscode\chef\bin\chef-client.bat -L C:/chef/log/client.log -c C:/chef/client.rb -s 60" "  ----
             Ran schtasks /CREATE /TN "chef-client" /F /SC "minute" /MO "30" /RU "SYSTEM" /RL "HIGHEST" /TR "cmd /c "C:\opscode\chef\bin\chef-client.bat -L C:/chef/log/client.log -c C:/chef/client.rb -s 60" "  returned -2147467259```