### PR TITLE
Add ability to set daemonized SSL trust store on AIX

### DIFF
--- a/recipes/src_service.rb
+++ b/recipes/src_service.rb
@@ -37,7 +37,11 @@ execute "install #{node['chef_client']['svc_name']} in SRC" do
 end
 
 execute "enable #{node['chef_client']['svc_name']}" do
-  command "mkitab '#{node['chef_client']['svc_name']}:2:once:/usr/bin/startsrc -s #{node['chef_client']['svc_name']} > /dev/console 2>&1'"
+  if node["chef_client"]["ca_cert_path"]
+    command "mkitab '#{node['chef_client']['svc_name']}:2:once:/usr/bin/startsrc -e \"SSL_CERT_FILE=#{node["chef_client"]["ca_cert_path"]}\" -s #{node['chef_client']['svc_name']} > /dev/console 2>&1'"
+  else
+    command "mkitab '#{node['chef_client']['svc_name']}:2:once:/usr/bin/startsrc -s #{node['chef_client']['svc_name']} > /dev/console 2>&1'"
+  end
   not_if "lsitab #{node['chef_client']['svc_name']}"
 end
 


### PR DESCRIPTION
Signed-off-by: Daniel Ruggeri druggeri@primary.net

### Description

I missed this in my PR from last year (#515). Add ability to set the SSL_CERT_FILE environment variable for daemonized clients _on AIX, too._ When not configured, no behavior changes.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
