### PR TITLE
[MSYS-747]update start_date format attribute

### DIFF
--- a/test/cookbooks/test/recipes/task.rb
+++ b/test/cookbooks/test/recipes/task.rb
@@ -1,6 +1,6 @@
 node.override['chef_client']['interval'] = 900
 node.override['chef_client']['task']['frequency_modifier'] = '31' # this is a string to test that "typo"
-node.override['chef_client']['task']['start_date'] = Time.now.strftime('%m/%m/%Y')
+node.override['chef_client']['task']['start_date'] = Time.now.strftime('%m/%d/%Y')
 
 include_recipe 'test::config'
 include_recipe 'chef-client::task'


### PR DESCRIPTION

### Description
`Time.now.strftime('%m/%m/%Y')` is not proper format so changed it to `Time.now.strftime('%m/%d/%Y')` 
