### PR TITLE
set node_name even if it matches fqdn

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@
 default['chef_client']['config'] = {
   'chef_server_url' => Chef::Config[:chef_server_url],
   'validation_client_name' => Chef::Config[:validation_client_name],
-  'node_name' => Chef::Config[:node_name] == node['fqdn'] ? false : Chef::Config[:node_name],
+  'node_name' => Chef::Config[:node_name],
   'verify_api_cert' => true,
 }
 


### PR DESCRIPTION
Signed-off-by: michael.sgarbossa <michael.sgarbossa@cvshealth.com>

### Description

Sets node_name in client.rb, even if Chef::Config[:node_name] matches the FQDN.  Best practice seems to be to put node_name in client.rb.  knife bootstrap does it by default and the chef-client cookbook removes it when it matches the fqdn.  Using knife with client.rb requires node_name to be set.  If the fqdn of a node is changed after it is bootstrapped, the client can no longer authenticate.  This PR ensures the default['chef_client']['config']['node_name'] attribute is set so it gets written to client.rb.

### Issues Resolved

#536 
#493 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
