### PR TITLE
Add random_delay to windows task

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,6 +73,7 @@ default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for none system users
 default['chef_client']['task']['start_time'] = nil
 default['chef_client']['task']['start_date'] = nil
+default['chef_client']['task']['random_delay'] = nil
 
 default['chef_client']['load_gems'] = {}
 

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -41,6 +41,7 @@ chef_client_scheduled_task 'Chef Client' do
   frequency_modifier lazy { node['chef_client']['task']['frequency_modifier'] }
   start_time node['chef_client']['task']['start_time']
   start_date node['chef_client']['task']['start_date']
+  random_delay node['chef_client']['task']['random_delay']
   splay node['chef_client']['splay']
   config_directory node['chef_client']['conf_dir']
   log_directory node['chef_client']['log_dir']

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -25,6 +25,7 @@ property :frequency, String, default: 'minute', equal_to: %w(minute hourly daily
 property :frequency_modifier, [Integer, String], default: 30
 property :start_date, String, regex: [%r{^[0-1][0-9]\/[0-3][0-9]\/\d{4}$}]
 property :start_time, String, regex: [/^\d{2}:\d{2}$/]
+property :random_delay, Integer, default: nil
 property :splay, [Integer, String], default: 300
 property :config_directory, String, default: 'C:/chef'
 property :log_directory, String, default: lazy { |r| "#{r.config_directory}/log" }
@@ -38,7 +39,6 @@ action :add do
   client_cmd = new_resource.chef_binary_path.dup
   client_cmd << " -L #{::File.join(new_resource.log_directory, node['chef_client']['log_file'])}" unless node['chef_client']['log_file'].nil?
   client_cmd << " -c #{::File.join(new_resource.config_directory, 'client.rb')}"
-  client_cmd << " -s #{new_resource.splay}"
 
   # Add custom options
   client_cmd << " #{new_resource.daemon_options.join(' ')}" if new_resource.daemon_options.any?
@@ -60,6 +60,7 @@ action :add do
     frequency_modifier new_resource.frequency_modifier
     start_time         start_time_value
     start_day          new_resource.start_date unless new_resource.start_date.nil?
+    random_dealy       new_resource.random_delay unless new_resource.start_delay.nil?
   end
 end
 


### PR DESCRIPTION
Signed-off-by: Antek S. Baranski antek.baranski@gmail.com

Removed the `-s splay` from the client_cmd options because this is
ignored on Windows anyway by chef-client.