### PR TITLE
Don't include the daemon options if they don't exist.

### DIFF
--- a/templates/default/suse/init.d/chef-client.erb
+++ b/templates/default/suse/init.d/chef-client.erb
@@ -29,8 +29,9 @@ PIDFILE=${PIDFILE-<%= node["chef_client"]["run_path"] %>/client.pid}
 LOCKFILE=${LOCKFILE-/var/lock/subsys/chef-client}
 INTERVAL=${INTERVAL-<%= node["chef_client"]["interval"] %>}
 SPLAY=${SPLAY-<%= node["chef_client"]["splay"] %>}
-OPTIONS=${OPTIONS-}
-
+<% unless node["chef_client"]["daemon_options"].empty? -%>
+OPTIONS=${OPTIONS-<%= node["chef_client"]["daemon_options"] %>}
+<% end %>
 
 # Source LSB init functions
 # providing start_daemon, killproc, pidofproc,
@@ -75,7 +76,7 @@ case "$1" in
         echo -n "Starting chef-client "
         ## Start daemon with startproc(8). If this fails
         ## the return value is set appropriately by startproc.
-        /sbin/startproc -p $PIDFILE $CHEF_CLIENT -d -c "$CONFIG" -P "$PIDFILE" -i "$INTERVAL" -s "$SPLAY" "$OPTIONS"
+        /sbin/startproc -p $PIDFILE $CHEF_CLIENT -d -c "$CONFIG" -P "$PIDFILE" -i "$INTERVAL" -s "$SPLAY" <% unless node["chef_client"]["daemon_options"].empty? %>"$OPTIONS"<% end %>
 
         # Remember status and be verbose
         rc_status -v


### PR DESCRIPTION
Also fix it so daemon options will exist if you specify them!

Apparently this will cause it to concatenate things and create an empty array, which eventually ends up as [/]

Signed-off-by: Scott Hain <shain@chef.io>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
