### PR TITLE
[cron] Be notified of chef-client failure if mailto attribute is defined

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -116,7 +116,8 @@ if node['chef_client']['cron']['use_cron_d']
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
     cmd << "#{env_vars} " if env_vars?
     cmd << "/bin/nice -n #{process_priority} " if process_priority
-    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1"
+    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1 "
+    cmd << '|| echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
     command cmd
   end
 else
@@ -135,7 +136,8 @@ else
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
     cmd << "#{env_vars} " if env_vars?
     cmd << "/bin/nice -n #{process_priority} " if process_priority
-    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1"
+    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1 "
+    cmd << '|| echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
     command cmd
   end
 end


### PR DESCRIPTION
### Description
Currently if you use the `cron` recipe and set the `node['chef_client']['cron']['mailto']` you never receive notification when `chef-client` fails.

With this PR, user will receive a mail if `chef-client` failed.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
