### PR TITLE
handle mixed lines if log_location is nil

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -14,10 +14,10 @@ end
   <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
 <%= option %> <%= @chef_config[option].to_s.gsub(/^:/, '').to_sym.inspect %>
   <% when 'log_location' -%>
-  <%   if @chef_config[option].instance_of? String -%>
+  <%   if (@chef_config[option].instance_of? String) || @chef_config[option].nil? -%>
 <%= option %> <%= @chef_config[option] == 'STDOUT' ? 'STDOUT' : @chef_config[option].inspect %>
   <%   else -%>
-<%= option %> <%= @chef_config[option] -%>
+<%= option %> <%= @chef_config[option] %>
   <%   end -%>
   <% else -%>
 <%= option %> <%= @chef_config[option].inspect %>


### PR DESCRIPTION
### Description

Fixes `log_location ssl_verify_mode :verify_none` (yes on same line) when `node['chef_client']['config']['log_location'] = nil`

The first fix is to remove "omit newline" in `.erb`: `%>` vs `-%>`, that would result:
```
log_location
ssl_verify_mode :verify_none
```

which is not syntax error anymore, but i've updated the if-condition so that the `nil` gets rendered as `nil` in output, which is more correct aesthetically.

```
log_location nil
ssl_verify_mode :verify_none
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
