### PR TITLE
handle empty (but not nil) handlers block

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -47,7 +47,7 @@ ohai.plugin_path << "<%= node["ohai"]["plugin_path"] %>"
 ohai.disabled_plugins = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]
 <% end -%>
 
-<% if !@start_handlers.nil? || !@report_handlers.nil? || !@exception_handlers.nil? -%>
+<% if !@start_handlers.empty? || !@report_handlers.empty? || !@exception_handlers.empty? -%>
 # Do not crash if a handler is missing / not installed yet
 begin
 <% unless @start_handlers.nil? -%>


### PR DESCRIPTION
### Description

Currently when all handlers are empty, the try-catch block is still written because the condition is made on `.nil?` check, but [default is defined as empty array: `[]`](https://github.com/chef-cookbooks/chef-client/blob/v10.0.0/attributes/default.rb#L79-L81).

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
