### PR TITLE
Fix the handling of log_locations that aren't strings

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -14,10 +14,10 @@ end
   <% when 'log_level', 'ssl_verify_mode', 'audit_mode' -%>
 <%= option %> <%= @chef_config[option].to_s.gsub(/^:/, '').to_sym.inspect %>
   <% when 'log_location' -%>
-  <%   if (@chef_config[option].instance_of? String) || @chef_config[option].nil? -%>
-<%= option %> <%= @chef_config[option] == 'STDOUT' ? 'STDOUT' : @chef_config[option].inspect %>
-  <%   else -%>
+  <%   if (@chef_config[option].instance_of? String) && @chef_config[option].match(/^(STDOUT|STDERR)$/) -%>
 <%= option %> <%= @chef_config[option] %>
+  <%   else -%>
+<%= option %> <%= @chef_config[option].inspect %>
   <%   end -%>
   <% else -%>
 <%= option %> <%= @chef_config[option].inspect %>


### PR DESCRIPTION
Signed-off-by: Peter Walz <pnw@umn.edu>

### Description

In Chef 12.9, `:syslog` and `:win_evt` were added as supported log locations in `client.rb`, adding to the existing `STDOUT`, `STDERR`, and file-based logging. Presently, the only locations supported by `chef-client::config` are `STDOUT` and file-based. (Chef interprets the strings `syslog` and `win_evt` as their corresponding symbols, but we should be able to use the symbols directly.)

This PR fixes `templates/default/client.rb.erb` so all of the `log_location` values are rendered correctly.

### Issues Resolved

See above.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
