### PR TITLE
Add client config require test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ env:
   - CHEF_VERSION=12 INSTANCE=cron-ubuntu-1604
   - CHEF_VERSION=12 INSTANCE=cron-centos-6
   - CHEF_VERSION=12 INSTANCE=cron-centos-7
+  - CHEF_VERSION=12 INSTANCE=config-ubuntu-1404
+  - CHEF_VERSION=12 INSTANCE=config-ubuntu-1604
+  - CHEF_VERSION=12 INSTANCE=config-centos-6
+  - CHEF_VERSION=12 INSTANCE=config-centos-7
   - CHEF_VERSION=12 INSTANCE=delete-validation-ubuntu-1604
   - CHEF_VERSION=12 INSTANCE=delete-validation-centos-7
   - CHEF_VERSION=12 INSTANCE=service-upstart-ubuntu-1404
@@ -38,6 +42,10 @@ env:
   - CHEF_VERSION=13 INSTANCE=cron-ubuntu-1604
   - CHEF_VERSION=13 INSTANCE=cron-centos-6
   - CHEF_VERSION=13 INSTANCE=cron-centos-7
+  - CHEF_VERSION=13 INSTANCE=config-ubuntu-1404
+  - CHEF_VERSION=13 INSTANCE=config-ubuntu-1604
+  - CHEF_VERSION=13 INSTANCE=config-centos-6
+  - CHEF_VERSION=13 INSTANCE=config-centos-7
   - CHEF_VERSION=13 INSTANCE=delete-validation-ubuntu-1604
   - CHEF_VERSION=13 INSTANCE=delete-validation-centos-7
   - CHEF_VERSION=13 INSTANCE=service-upstart-ubuntu-1404

--- a/README.md
+++ b/README.md
@@ -192,15 +192,15 @@ default_attributes(
 The `/etc/chef/client.rb` file will include all the configuration files in `/etc/chef/client.d/*.rb`. To create custom configuration, simply render a file resource with `file` (and the `content` parameter), `template`, `remote_file`, or `cookbook_file`. For example, in your own cookbook that requires custom Chef client configuration, create the following `cookbook_file` resource:
 
 ```ruby
+include_recipe 'chef-client::config'
+
 chef_gem 'syslog-logger'
 
-cookbook_file "/etc/chef/client.d/myconfig.rb" do
-  source "myconfig.rb"
+cookbook_file '/etc/chef/client.d/myconfig.rb' do
+  source 'myconfig.rb'
   mode '0644'
-  notifies :create, "ruby_block[reload_client_config]"
+  notifies :create, 'ruby_block[reload_client_config]'
 end
-
-include_recipe 'chef-client::config'
 ```
 
 Then create `files/default/myconfig.rb` with the configuration content you want. For example, if you wish to create a configuration to log to syslog:

--- a/test/cookbooks/test/files/default/myconfig.rb
+++ b/test/cookbooks/test/files/default/myconfig.rb
@@ -1,8 +1,7 @@
-require 'syslog-logger'
-require 'syslog'
+require 'logutils'
 
-Logger::Syslog.class_eval do
-  attr_accessor :sync, :formatter
+Chef.event_handler do
+  on :run_failed do |exception|
+    LogUtils::Logger.error("Hit an exception: #{exception.message}")
+  end
 end
-
-log_location Chef::Log::Syslog.new('chef-client', ::Syslog::LOG_DAEMON)

--- a/test/cookbooks/test/files/default/myconfig.rb
+++ b/test/cookbooks/test/files/default/myconfig.rb
@@ -1,0 +1,8 @@
+require 'syslog-logger'
+require 'syslog'
+
+Logger::Syslog.class_eval do
+  attr_accessor :sync, :formatter
+end
+
+log_location Chef::Log::Syslog.new('chef-client', ::Syslog::LOG_DAEMON)

--- a/test/cookbooks/test/recipes/config.rb
+++ b/test/cookbooks/test/recipes/config.rb
@@ -7,7 +7,7 @@ chef_gem 'syslog-logger' do
   compile_time false
 end
 
-cookbook_file '/etc/chef/client.d/myconfig.rb' do
+cookbook_file "#{Chef::Config[:client_d_dir]}/myconfig.rb" do
   source 'myconfig.rb'
   mode '0644'
   notifies :create, 'ruby_block[reload_client_config]'

--- a/test/cookbooks/test/recipes/config.rb
+++ b/test/cookbooks/test/recipes/config.rb
@@ -3,8 +3,14 @@ node.override['ohai']['plugin_path'] = '/tmp/kitchen/ohai/plugins'
 
 include_recipe 'chef-client::config'
 
-chef_gem 'syslog-logger' do
+chef_gem 'logutils' do
   compile_time false
+end
+
+directory Chef::Config[:client_d_dir] do
+  recursive true
+  owner 'root'
+  group 'root'
 end
 
 cookbook_file "#{Chef::Config[:client_d_dir]}/myconfig.rb" do

--- a/test/cookbooks/test/recipes/config.rb
+++ b/test/cookbooks/test/recipes/config.rb
@@ -3,7 +3,9 @@ node.override['ohai']['plugin_path'] = '/tmp/kitchen/ohai/plugins'
 
 include_recipe 'chef-client::config'
 
-chef_gem 'syslog-logger'
+chef_gem 'syslog-logger' do
+  compile_time false
+end
 
 cookbook_file '/etc/chef/client.d/myconfig.rb' do
   source 'myconfig.rb'

--- a/test/cookbooks/test/recipes/config.rb
+++ b/test/cookbooks/test/recipes/config.rb
@@ -1,3 +1,12 @@
 node.override['ohai']['disabled_plugins'] = ['Mdadm']
 node.override['ohai']['plugin_path'] = '/tmp/kitchen/ohai/plugins'
+
 include_recipe 'chef-client::config'
+
+chef_gem 'syslog-logger'
+
+cookbook_file '/etc/chef/client.d/myconfig.rb' do
+  source 'myconfig.rb'
+  mode '0644'
+  notifies :create, 'ruby_block[reload_client_config]'
+end


### PR DESCRIPTION
### Description

This updates the example in the README for loading a custom client.d configuration and also [proves out a bug that I believe I found in Chef](https://github.com/chef/chef/issues/7088) when it comes to loading the client.d folder and gem paths.

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
