### PR TITLE
Use RandomizedDelaySec for splay on systemd timer

### DIFF
--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -80,7 +80,7 @@ systemd_unit 'chef-client.timer' do
     'Timer' => {
       'OnBootSec' => '1min',
       'OnUnitActiveSec' => "#{node['chef_client']['interval']}sec",
-      'AccuracySec' => "#{node['chef_client']['splay']}sec",
+      'RandomizedDelaySec' => "#{node['chef_client']['splay']}sec",
     }
   )
   action(timer ? [:create, :enable, :start] : [:stop, :disable, :delete])


### PR DESCRIPTION
### Description

This replaces the AccuracySec option for the systemd timer with RandomizedDelaySec as it is better suited for randomizing the interval of the timer. Here is the quoted manpage for RandomizedDelaySec:

> Delay the timer by a randomly selected, evenly distributed amount of time between 0 and the specified time value. Defaults to 0, indicating that no randomized delay shall be applied. Each timer unit will determine this delay randomly each time it is started, and the delay will simply be added on top of the next determined elapsing time. This is useful to stretch dispatching of similarly configured timer events over a certain amount time, to avoid that they all fire at the same time, possibly resulting in resource congestion. Note the relation to AccuracySec= above: the latter allows the service manager to coalesce timer events within a specified time range in order to minimize wakeups, the former does the opposite: it stretches timer events over a time range, to make it unlikely that they fire simultaneously. If RandomizedDelaySec= and AccuracySec= are used in conjunction, first the randomized delay is added, and then the result is possibly further shifted to coalesce it with other timer events happening on the system. As mentioned above AccuracySec= defaults to 1min and RandomizedDelaySec= to 0, thus encouraging coalescing of timer events. In order to optimally stretch timer events over a certain range of time, make sure to set RandomizedDelaySec= to a higher value, and AccuracySec=1us.

### Issues Resolved

None

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
