### PR TITLE
Fix failures on Windows with Chef 14

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,8 +46,7 @@ module Opscode
         d_owner = root_owner
         %w(run_path cache_path backup_path log_dir conf_dir).each do |dir|
           # Do not redefine the resource if it exist
-          next if find_resource(:directory, node['chef_client'][dir])
-          directory node['chef_client'][dir] do
+          find_resource(:directory, node['chef_client'][dir]) do
             recursive true
             mode '0755' if dir == 'log_dir'
             owner d_owner

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,15 +46,12 @@ module Opscode
         d_owner = root_owner
         %w(run_path cache_path backup_path log_dir conf_dir).each do |dir|
           # Do not redefine the resource if it exist
-          begin
-            resources(directory: node['chef_client'][dir])
-          rescue Chef::Exceptions::ResourceNotFound
-            directory node['chef_client'][dir] do
-              recursive true
-              mode '0755' if dir == 'log_dir'
-              owner d_owner
-              group node['root_group']
-            end
+          next if find_resource(:directory, node['chef_client'][dir])
+          directory node['chef_client'][dir] do
+            recursive true
+            mode '0755' if dir == 'log_dir'
+            owner d_owner
+            group node['root_group']
           end
         end
       end


### PR DESCRIPTION
We have a fix in master that restores the resources method, but we should unbreak Chef 14.0.190 users. This does exactly that and actually cleans up the code a bit too

Signed-off-by: Tim Smith <tsmith@chef.io>