### PR TITLE
Fix chef-client path check on Windows

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,7 +73,7 @@ module Opscode
           Chef::Log.debug 'Using chef-client bin from node attributes'
           node['chef_client']['bin']
         # last ditch search for a bin in PATH
-        elsif (chef_in_path = shell_out("#{which} chef-client").stdout.chomp) && ::File.send(existence_check, chef_in_path)
+        elsif (chef_in_path = shell_out("#{which} chef-client").stdout.chomp.split(/\r\n/).first) && ::File.send(existence_check, chef_in_path)
           Chef::Log.debug 'Using chef-client bin from system path'
           chef_in_path
         else


### PR DESCRIPTION
### Description

This fixes a very specific issue where the chef-client cookbook attempts to determine where the chef-client binary lives but can't because of multiple `chef-client` items listed in the system path. The shell_out command to determine where chef-client is on the path assumes that only one entry will be returned. However, if there are multiple instances of chef-client on the system path, the existence check fails. 

For example. With the current method, the `chef_in_path` variable will be populated with something like the following if multiple `chef-client` entries are found on the path:

```
pry(#<Chef::Recipe>)> chef_in_path = shell_out("#{which} chef-client").stdout.chomp
=> "C:\\opscode\\chefdk\\bin\\chef-client\r\nC:\\opscode\\chefdk\\embedded\\bin\\chef-client"
```

When the results of this are fed to the existence check, it fails due to there being two entries of `chef-client` on the system path represented by one string. Adding the `.split(/\r\n/).first` methods to the results of the shell_out results will check for the existence of the first instance of `chef-client` on the system path. For example:

```
pry(#<Chef::Recipe>)> chef_in_path = shell_out("#{which} chef-client").stdout.chomp.split(/\r\n/).first
=> "C:\\opscode\\chefdk\\bin\\chef-client"
```

### Issues Resolved

None

### Check List

- [ X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X ] New functionality includes testing.
- [ X ] New functionality has been documented in the README if applicable
- [ X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
