### PR TITLE
[GH-558] Add chef_client_scheduled_task name property

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['task']['start_date']` - The start date for the task in `m:d:Y` format (ex: 12/17/2017). nil by default and isn't necessary if you're running a regular interval.
 - `node['chef_client']['task']['user']` - The user the scheduled task will run as, defaults to `'SYSTEM'`.
 - `node['chef_client']['task']['password']` - The password for the user the scheduled task will run as, defaults to `nil` because the default user, `'SYSTEM'`, does not need a password.
+- `node['chef_client']['task']['name']` - The name of the scheduled task, defaults to `chef-client`.
 
 The following attributes are set on a per-platform basis, see the `attributes/default.rb` file for default values.
 
@@ -321,6 +322,7 @@ The chef_client_scheduled_task setups up chef-client to run as a scheduled task.
 - `log_directory` - The path to the Chef log directory. default: 'CONFIG_DIRECTORY/log'
 - `chef_binary_path` - The path to the chef-client binary. default: 'C:/opscode/chef/bin/chef-client'
 - `daemon_options` - An optional array of extra options to pass to the chef-client
+- `name` - The name of the scheduled task. This allows for multiple chef_client_scheduled_task resources when it is used directly like in a wrapper cookbook. default: 'chef-client'
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The chef_client_scheduled_task setups up chef-client to run as a scheduled task.
 - `log_directory` - The path to the Chef log directory. default: 'CONFIG_DIRECTORY/log'
 - `chef_binary_path` - The path to the chef-client binary. default: 'C:/opscode/chef/bin/chef-client'
 - `daemon_options` - An optional array of extra options to pass to the chef-client
-- `name` - The name of the scheduled task. This allows for multiple chef_client_scheduled_task resources when it is used directly like in a wrapper cookbook. default: 'chef-client'
+- `task_name` - The name of the scheduled task. This allows for multiple chef_client_scheduled_task resources when it is used directly like in a wrapper cookbook. default: 'chef-client'
 
 ## Maintainers
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,6 +73,7 @@ default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for none system users
 default['chef_client']['task']['start_time'] = nil
 default['chef_client']['task']['start_date'] = nil
+default['chef_client']['task']['name'] = 'chef-client'
 
 default['chef_client']['load_gems'] = {}
 

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -46,4 +46,5 @@ chef_client_scheduled_task 'Chef Client' do
   log_directory node['chef_client']['log_dir']
   chef_binary_path node['chef_client']['bin']
   daemon_options node['chef_client']['daemon_options']
+  name node['chef_client']['task']['name']
 end

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -46,5 +46,5 @@ chef_client_scheduled_task 'Chef Client' do
   log_directory node['chef_client']['log_dir']
   chef_binary_path node['chef_client']['bin']
   daemon_options node['chef_client']['daemon_options']
-  name node['chef_client']['task']['name']
+  task_name node['chef_client']['task']['name']
 end

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -30,7 +30,7 @@ property :config_directory, String, default: 'C:/chef'
 property :log_directory, String, default: lazy { |r| "#{r.config_directory}/log" }
 property :chef_binary_path, String, default: 'C:/opscode/chef/bin/chef-client'
 property :daemon_options, Array, default: []
-property :name, String, default: 'chef-client'
+property :task_name, String, default: 'chef-client'
 
 action :add do
   create_chef_directories
@@ -52,7 +52,7 @@ action :add do
                    "cmd /c \'#{client_cmd}\'"
                  end
 
-  windows_task new_resource.name do
+  windows_task new_resource.task_name do
     run_level :highest
     command full_command
     user               new_resource.user
@@ -65,7 +65,7 @@ action :add do
 end
 
 action :remove do
-  windows_task new_resource.name do
+  windows_task new_resource.task_name do
     action :delete
   end
 end

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -30,6 +30,7 @@ property :config_directory, String, default: 'C:/chef'
 property :log_directory, String, default: lazy { |r| "#{r.config_directory}/log" }
 property :chef_binary_path, String, default: 'C:/opscode/chef/bin/chef-client'
 property :daemon_options, Array, default: []
+property :name, String, default: 'chef-client'
 
 action :add do
   create_chef_directories
@@ -51,7 +52,7 @@ action :add do
                    "cmd /c \'#{client_cmd}\'"
                  end
 
-  windows_task 'chef-client' do
+  windows_task new_resource.name do
     run_level :highest
     command full_command
     user               new_resource.user
@@ -64,7 +65,7 @@ action :add do
 end
 
 action :remove do
-  windows_task 'chef-client' do
+  windows_task new_resource.name do
     action :delete
   end
 end


### PR DESCRIPTION
* name property allows multiple chef_client_scheduled_task resources to be used
  in wrapper cookbooks.

Signed-off-by: Jonathan An <jan@esri.com>

### Description

Allows multiple chef_client_scheduled_task resources to be used.

### Issues Resolved

https://github.com/chef-cookbooks/chef-client/issues/558

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
