### PR TITLE
scheduled task user and password should be marked as sensitive

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -19,8 +19,8 @@
 
 resource_name :chef_client_scheduled_task
 
-property :user, String, default: 'System'
-property :password, String
+property :user, String, default: 'System', sensitive: true
+property :password, String, sensitive: true
 property :frequency, String, default: 'minute', equal_to: %w(minute hourly daily monthly once on_logon onstart on_idle)
 property :frequency_modifier, [Integer, String], default: 30
 property :start_date, String, regex: [%r{^[0-1][0-9]\/[0-3][0-9]\/\d{4}$}]


### PR DESCRIPTION
Signed-off-by: S. Cavallo <smcavallo@hotmail.com>

### Description
scheduled task user and password should be marked as sensitive
they should not appear in chef logs or exceptions

### Issues Resolved

### Check List

- [X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
