### PR TITLE
fix issues with a new instance where `chef-client` service is not found

### DIFF
--- a/recipes/upstart_service.rb
+++ b/recipes/upstart_service.rb
@@ -9,12 +9,19 @@ Chef::Log.debug("Using chef-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 
+# reload the upstart services
+execute 'initctl-reload-configuration' do
+  command 'initctl reload-configuration'
+  action :nothing
+end
+
 template '/etc/init/chef-client.conf' do
   source 'debian/init/chef-client.conf.erb'
   mode '0644'
   variables(
     client_bin: client_bin
   )
+  notifies :run, 'execute[initctl-reload-configuration]', :immediate
   notifies :restart, 'service[chef-client]', :delayed
 end
 


### PR DESCRIPTION
upstart requires you to reload whenever you add a new template or it will fail.

Recipe output:
```
Recipe: chef-client::upstart_service
  * service[chef-client] action restart

    ============================================================================
    Error executing action `restart` on resource 'service[chef-client]'
    ============================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '1'
    ---- Begin output of /sbin/start chef-client ----
    STDOUT:
    STDERR: start: Unknown job: chef-client
    ---- End output of /sbin/start chef-client ----
    Ran /sbin/start chef-client returned 1

    Resource Declaration:
    ---------------------
    # In /opt/kitchen/cache/cookbooks/chef-client/recipes/upstart_service.rb

     21: service 'chef-client' do
     22:   provider Chef::Provider::Service::Upstart
     23:   action [:enable, :start]
     24: end

    Compiled Resource:
    ------------------
    # Declared in /opt/kitchen/cache/cookbooks/chef-client/recipes/upstart_serv'

    service("chef-client") do
      provider Chef::Provider::Service::Upstart
      action [:enable, :start]
      default_guard_interpreter :default
      service_name "chef-client"
      enabled true
      running false
      masked nil
      pattern "chef-client"
      declared_type :service
      cookbook_name "chef-client"
      recipe_name "upstart_service"
    end

    System Info:
    ------------
    chef_version=13.8.13
    platform=ubuntu
    platform_version=14.04
    ruby=ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]
    program_name=chef-client worker: ppid=61;start=20:53:03;
    executable=/opt/chef/embedded/bin/chef-client

Running handlers:
[2018-05-10T21:03:35+00:00] ERROR: Running exception handlers
[2018-05-10T21:03:35+00:00] ERROR: Running exception handlers
Running handlers complete
[2018-05-10T21:03:35+00:00] ERROR: Exception handlers complete
[2018-05-10T21:03:35+00:00] ERROR: Exception handlers complete
Chef Client failed. 34 resources updated in 10 minutes 31 seconds
[2018-05-10T21:03:35+00:00] ERROR: undefined method `exceptions' for nil:NilClas
[2018-05-10T21:03:35+00:00] ERROR: undefined method `exceptions' for nil:NilClas
[2018-05-10T21:03:35+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef r)
[2018-05-10T21:03:35+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef r)
```

Verifying it is not a purely chef problem:
```
root@dokken:/# service chef-client status
status: Unknown job: chef-client

root@dokken:/# service chef-client.conf status
chef-client.conf: unrecognized service

root@dokken:/# initctl reload-configuration

root@dokken:/# initctl list | grep chef
chef-client stop/waiting
```

I discussed this with Tim Smith and unfortunately there is no good place to put this in the current `upstart` provider as we do not manage the actual service script itself and having the template notify makes the most sense.

Signed-off-by: Ben Abrams me@benabrams.it

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
