### PR TITLE
Add root_group method for quering WMI for root group on Windows platform

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -41,16 +41,25 @@ module Opscode
         end
       end
 
+      def root_group
+        if ['windows'].include?(node['platform'])
+          wmi_property_from_query(:name, "select * from win32_group where sid like 'S-1-5-32-544' and LocalAccount=True")
+        else
+          node['root_group']
+        end
+      end
+
       def create_chef_directories
-        # root_owner is not in scope in the block below.
+        # root_owner and root_group are not in scope in the block below.
         d_owner = root_owner
+        d_group = root_group
         %w(run_path cache_path backup_path log_dir conf_dir).each do |dir|
           # Do not redefine the resource if it exist
           find_resource(:directory, node['chef_client'][dir]) do
             recursive true
             mode '0755' if dir == 'log_dir'
             owner d_owner
-            group node['root_group']
+            group d_group
           end
         end
       end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -74,11 +74,12 @@ end
 # We need to set these local variables because the methods aren't
 # available in the Chef::Resource scope
 d_owner = root_owner
+d_group = root_group
 
 template "#{node['chef_client']['conf_dir']}/client.rb" do
   source 'client.rb.erb'
   owner d_owner
-  group node['root_group']
+  group d_group
   mode '0644'
   variables(
     chef_config: node['chef_client']['config'],
@@ -97,7 +98,7 @@ end
 directory ::File.join(node['chef_client']['conf_dir'], 'client.d') do
   recursive true
   owner d_owner
-  group node['root_group']
+  group d_group
   mode '0755'
 end
 


### PR DESCRIPTION
### Description

Use root_group method instead of attribute as `node['root_group']` can 
return invalid encoding on non-English version of Windows.

Signed-off-by: Anton Kvashenkin <anton.jugatsu@gmail.com>

### Issues Resolved

https://github.com/chef-cookbooks/chef-client/issues/581