### PR TITLE
Chef 14.4.0 requires double quotes around command for scheduled task

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -31,18 +31,35 @@ platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04
-  - name: windows-2012r2
-    driver:
-      box: chef/windows-server-2012r2-standard # private box
   - name: windows-2016
-    driver:
-      box: chef/windows-server-2016-standard # private box
-  - name: windows-2016-13.6
     provisioner:
       product_name: chef
-      product_version: 13.6
+    transport:
+      name: winrm
+      elevated: true
     driver:
-      box: chef/windows-server-2016-standard # private box
+      box: chef/windows-server-2016-standard # private box      
+    transport:
+      name: winrm
+      elevated: true
+  - name: windows-2012r2-13
+    provisioner:
+      product_name: chef
+      product_version: 13
+    driver:
+      box: chef/windows-server-2012r2-standard # private box
+    transport:
+      name: winrm
+      elevated: true
+  - name: windows-2012r2-14
+    provisioner:
+      product_name: chef
+      product_version: 14
+    driver:
+      box: chef/windows-server-2012r2-standard # private box
+    transport:
+      name: winrm
+      elevated: true
 
 suites:
 - name: service_bsd
@@ -73,7 +90,7 @@ suites:
 - name: cron
   run_list:
   - recipe[test::cron]
-  excludes: ["windows-2012r2", "windows-2016", "windows-2016-13.6"]
+  excludes: ["windows-2012r2-13", "windows-2012r2-14", "windows-2016"]
 
 - name: cron_daemon
   run_list:
@@ -81,7 +98,7 @@ suites:
   attributes:
     chef_client:
       daemon_options: ["--run-lock-timeout 0"]
-  excludes: ["windows-2012r2", "windows-2016", "windows-2016-13.6"]
+  excludes: ["windows-2012r2-13", "windows-2012r2-14", "windows-2016"]
 
 - name: timer_systemd
   run_list:
@@ -95,15 +112,15 @@ suites:
 - name: config
   run_list:
     - recipe[test::config]
-  excludes: ["windows-2012r2", "windows-2016", "windows-2016-13.6"]
+  excludes: ["windows-2012r2-13", "windows-2012r2-14", "windows-2016"]
 
 # Test that the we can use the cron_d directory
 - name: use_cron_d
   run_list:
     - recipe[test::cook-use_cron_d]
-  excludes: ["windows-2012r2", "windows-2016", "windows-2016-13.6"]
+  excludes: ["windows-2012r2-13", "windows-2012r2-14", "windows-2016"]
 
 - name: task
   run_list:
     - recipe[test::task]
-  includes: ["windows-2012r2", "windows-2016", "windows-2016-13.6"]
+  includes: ["windows-2012r2-13", "windows-2012r2-14", "windows-2016"]

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -44,9 +44,9 @@ action :add do
   # Add custom options
   client_cmd << " #{new_resource.daemon_options.join(' ')}" if new_resource.daemon_options.any?
 
-  # This block is here due to the changes in windows_task in 13.7
-  # This can be removed once we no longer support < 13.7
-  full_command = if Gem::Requirement.new('< 13.7.0').satisfied_by?(Gem::Version.new(Chef::VERSION))
+  # Between Chef Client 13.7 and 14.3 we required the command to be surrounded in single quotes
+  # due to parsing problems with windows_task. Since 14.4 resolved we require double quotes around the command.
+  full_command = if Gem::Requirement.new('< 13.7.0').satisfied_by?(Gem::Version.new(Chef::VERSION)) || Gem::Requirement.new('>= 14.4.0').satisfied_by?(Gem::Version.new(Chef::VERSION))
                    "cmd /c \"#{client_cmd}\""
                  else
                    "cmd /c \'#{client_cmd}\'"


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Chef 14.4.56 "fixed" the windows_task resource in way that requires consumers to be use double quotes to surround the command arguments for any scheduled task that needed creating.  The existing chef-client cookbook used single quotes (which was required in the case of Chef 13.7 up to 14.3).  This PR checks the version of Chef and passes in the appropriately styled command property.  The tests have not changed, we've just added code to solve the problem if Chef 14.4 upwards is being used.

We also included changes to the kitchen configuration to test the "latest" Chef 13 and the "latest" Chef 14 version in the stable channel at the time of testing so that we can catch these earlier.

**Before change**
```
       Downloading files from <task-windows-2012r2-14>
       Finished converging <task-windows-2012r2-14> (1m44.38s).
-----> Setting up <task-windows-2012r2-14>...
       Finished setting up <task-windows-2012r2-14> (0m0.00s).
-----> Verifying <task-windows-2012r2-14>...
       Loaded tests from {:path=>"C:.projects.chef-cookbooks.chef-client.test.integration.task"}

Profile: tests from {:path=>"C:/projects/chef-cookbooks/chef-client/test/integration/task"} (tests from {:path=>"C:.projects.chef-cookbooks.chef-client.test.integration.task"})
Version: (not specified)
Target:  winrm://vagrant@http://172.27.16.132:5985/wsman:3389

  Command: `C:/opscode/chef/embedded/bin/ohai virtualization -c C:/chef/client.rb`
     [PASS]  exit_status should eq 0
  File C:/chef/client.rb
     [PASS]  content should match /ohai.disabled_plugins = \["Mdadm"\]/
     [PASS]  content should match /ohai.plugin_path << "\/tmp\/kitchen\/ohai\/plugins"/
  Windows Task 'chef-client'
     [PASS]  should be enabled
     [PASS]  run_as_user should eq "SYSTEM"
     [FAIL]  task_to_run should match "cmd /c C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300"
     expected "cmd /c 'C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300'" to match "cmd /c C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300"

Test Summary: 5 successful, 1 failure, 0 skipped
```

**After change**
```
       Downloading files from <task-windows-2012r2-14>
       Finished converging <task-windows-2012r2-14> (1m51.86s).
-----> Setting up <task-windows-2012r2-14>...
       Finished setting up <task-windows-2012r2-14> (0m0.00s).
-----> Verifying <task-windows-2012r2-14>...
       Loaded tests from {:path=>"C:.projects.chef-cookbooks.chef-client.test.integration.task"}

Profile: tests from {:path=>"C:/projects/chef-cookbooks/chef-client/test/integration/task"} (tests from {:path=>"C:.projects.chef-cookbooks.chef-client.test.integration.task"})
Version: (not specified)
Target:  winrm://vagrant@http://172.27.16.142:5985/wsman:3389

  Command: `C:/opscode/chef/embedded/bin/ohai virtualization -c C:/chef/client.rb`
     [PASS]  exit_status should eq 0
  File C:/chef/client.rb
     [PASS]  content should match /ohai.disabled_plugins = \["Mdadm"\]/
     [PASS]  content should match /ohai.plugin_path << "\/tmp\/kitchen\/ohai\/plugins"/
  Windows Task 'chef-client'
     [PASS]  should be enabled
     [PASS]  run_as_user should eq "SYSTEM"
     [PASS]  task_to_run should match "cmd /c C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300"

Test Summary: 6 successful, 0 failures, 0 skipped
       Finished verifying <task-windows-2012r2-14> (0m3.66s).
```

### Issues Resolved

Fixes #583 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
