### PR TITLE
Fix warning about ownership of client.log on Windows platform

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -49,8 +49,14 @@ end
 # libraries/helpers.rb method to DRY directory creation resources
 create_chef_directories
 
+# We need to set these local variables because the methods aren't
+# available in the Chef::Resource scope
+d_owner = root_owner
+
 if log_path != 'STDOUT'
   file log_path do
+    owner d_owner
+    group node['root_group']
     mode node['chef_client']['log_perm']
   end
 end
@@ -70,10 +76,6 @@ node['chef_client']['load_gems'].each do |gem_name, gem_info_hash|
   end
   chef_requires.push(gem_info_hash[:require_name] || gem_name)
 end
-
-# We need to set these local variables because the methods aren't
-# available in the Chef::Resource scope
-d_owner = root_owner
 
 template "#{node['chef_client']['conf_dir']}/client.rb" do
   source 'client.rb.erb'


### PR DESCRIPTION
Signed-off-by: Anton Kvashenkin <anton.jugatsu@gmail.com>

### Description

Fix warning about ownership of `client.log` file on Windows platform.

```
* file[C:/chef/log/client.log] action create[2018-09-15T02:38:19-07:00] WARN: Mode 640 includes bits for the owner, but owner is not specified
       [2018-09-15T02:38:19-07:00] WARN: Mode 640 includes bits for the group, but group is not specified
        (up to date)
```