### PR TITLE
Remove create_chef_directories method from scheduled_task resource

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -33,8 +33,6 @@ property :daemon_options, Array, default: []
 property :task_name, String, default: 'chef-client'
 
 action :add do
-  create_chef_directories
-
   # Build command line to pass to cmd.exe
   client_cmd = new_resource.chef_binary_path.dup
   client_cmd << " -L #{::File.join(new_resource.log_directory, node['chef_client']['log_file'])}" unless node['chef_client']['log_file'].nil?


### PR DESCRIPTION
### Description
We don't need this helper in resource as all directories are created via chef-client::config recipe. Also in some cases it's not necessary to create this folders as we may use chef_client_scheduled_task resource separately.

Signed-off-by: Anton Kvashenkin <anton.jugatsu@gmail.com>