### PR TITLE
Add onstart property to chef_client_scheduled_task resource

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,6 +73,7 @@ default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for none system users
 default['chef_client']['task']['start_time'] = nil
 default['chef_client']['task']['start_date'] = nil
+default['chef_client']['task']['onstart'] = false
 default['chef_client']['task']['name'] = 'chef-client'
 
 default['chef_client']['load_gems'] = {}

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -37,6 +37,7 @@ end
 chef_client_scheduled_task 'Chef Client' do
   user node['chef_client']['task']['user']
   password node['chef_client']['task']['password']
+  onstart node['chef_client']['task']['onstart']
   frequency node['chef_client']['task']['frequency']
   frequency_modifier lazy { node['chef_client']['task']['frequency_modifier'] }
   start_time node['chef_client']['task']['start_time']


### PR DESCRIPTION
With this new property we can control creation of additional scheduled task to run chef-client on Windows boot.

Signed-off-by: Anton Kvashenkin <anton.jugatsu@gmail.com>

### Issues Resolved

Partially resolves https://github.com/chef-cookbooks/chef-client/issues/409

I think it would be better to use an additional property `onstart` rather than `frequency` with `onstart` value because in this case we can use only _one_ `chef_client_scheduled_task` resource.