### PR TITLE
Express special strings for log_location as corresponding symbol

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -138,4 +138,37 @@ describe 'chef-client::config' do
         .with_content(/^log_location :syslog$/)
     end
   end
+
+  context 'Stringy Symbol-ized Log Location' do
+    # use let instead of cached because we're going to change an attribute
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+        node.normal['chef_client']['config']['log_level'] = ':debug'
+        node.normal['chef_client']['config']['log_location'] = log_location
+        node.normal['chef_client']['config']['ssl_verify_mode'] = ':verify_none'
+      end.converge(described_recipe)
+    end
+
+    %w(:syslog syslog).each do |string|
+      context "with #{string}" do
+        let(:log_location) { string }
+
+        it 'renders log_location as a symbol' do
+          expect(chef_run).to render_file('/etc/chef/client.rb') \
+            .with_content(/^log_location :syslog$/)
+        end
+      end
+    end
+
+    %w(:win_evt win_evt).each do |string|
+      context "with #{string}" do
+        let(:log_location) { string }
+
+        it 'renders log_location as a symbol' do
+          expect(chef_run).to render_file('/etc/chef/client.rb') \
+            .with_content(/^log_location :win_evt$/)
+        end
+      end
+    end
+  end
 end

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -16,6 +16,8 @@ end
   <% when 'log_location' -%>
   <%   if (@chef_config[option].instance_of? String) && @chef_config[option].match(/^(STDOUT|STDERR)$/) -%>
 <%= option %> <%= @chef_config[option] %>
+  <%   elsif (@chef_config[option].instance_of? String) && @chef_config[option].match(/^:?(syslog|win_evt)$/) -%>
+<%= option %> <%= @chef_config[option].to_s.gsub(/^:/, '').to_sym.inspect %>
   <%   else -%>
 <%= option %> <%= @chef_config[option].inspect %>
   <%   end -%>


### PR DESCRIPTION
### Description

This change converts the configuration attribute `log_location` from either the string `"syslog"` or `":syslog"` to the symbol `:syslog`. If the actual `log_location` setting in `client.rb` is `"syslog"`, then it works just like `:syslog`. However, if the string is `":syslog"`, `chef-client` will do what is probably intended in daemon mode but not in the foreground.

In any event, when someone sets the attribute to the string `":syslog"`, it is probably the case that they want the symbol `:syslog`. Also, someone who sees the string `"syslog"` in `client.rb` might be confused as to what is really happening.

Also, I tilted at my anti-bundler sentiment a bit by changing the comments in `Gemfile`. Bundler and ChefDK do not play well together. I am willing to discard that commit if desired.

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
