### PR TITLE
Do not attempt to delete a cron_d resource on AIX.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef-client cookbook.
 
+## 11.0.2 (2018-10-12)
+
+- Do not attempt to delete a cron_d resource on AIX hosts.
+
 ## 11.0.1 (2018-09-14)
 
 - [cron] Be notified of chef-client failure if mailto is defined

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '11.0.1'
+version           '11.0.2'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::bsd_service', 'Configures chef-client as a service on *BSD'
 recipe 'chef-client::config', 'Configures the client.rb from a template.'

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -121,8 +121,11 @@ if node['chef_client']['cron']['use_cron_d']
     command cmd
   end
 else
-  cron_d 'chef-client' do
-    action :delete
+  # AIX does not support cron.d so we won't try to remove a cron_d resource.
+  unless node['platform_family'] == 'aix'
+  	cron_d 'chef-client' do
+  	  action :delete
+  	end
   end
 
   cron 'chef-client' do

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -123,9 +123,9 @@ if node['chef_client']['cron']['use_cron_d']
 else
   # AIX does not support cron.d so we won't try to remove a cron_d resource.
   unless node['platform_family'] == 'aix'
-  	cron_d 'chef-client' do
-  	  action :delete
-  	end
+    cron_d 'chef-client' do
+      action :delete
+    end
   end
 
   cron 'chef-client' do


### PR DESCRIPTION
Signed-off-by: Ryan Frantz <ryanleefrantz@gmail.com>

### Description

AIX does not support `cron.d` so we will not attempt to remove an old `cron_d` resource in that case.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
