### PR TITLE
Create the Chef log directory if missing. Otherwise scheduled tasks fail

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -24,7 +24,7 @@ class ::Chef::Recipe
 end
 
 # create a directory in case the log director does not exist
-directory "C:\\chef\\log" do
+directory 'C:\chef\log' do
   inherits true
   recursive true
   action :create

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -23,6 +23,13 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
+# create a directory in case the log director does not exist
+directory "C:\\chef\\log" do
+  inherits true
+  recursive true
+  action :create
+end
+
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
 Chef::Log.info("Using chef-client binary at #{client_bin}")


### PR DESCRIPTION
…ail.

### Description

By default the scheduled runs fail because of a missing log directory. This created the log directory recursively on Windows boxes.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
