### PR TITLE
Stop chef-client windows service after creating scheduled task

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -35,12 +35,6 @@ client_bin = find_chef_client
 Chef::Log.info("Using chef-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 
-windows_service 'chef-client' do
-  startup_type :disabled
-  action :configure_startup
-  only_if { ::Win32::Service.exists?('chef-client') }
-end
-
 chef_client_scheduled_task 'Chef Client' do
   user node['chef_client']['task']['user']
   password node['chef_client']['task']['password']
@@ -54,4 +48,10 @@ chef_client_scheduled_task 'Chef Client' do
   chef_binary_path node['chef_client']['bin']
   daemon_options node['chef_client']['daemon_options']
   task_name node['chef_client']['task']['name']
+end
+
+windows_service 'chef-client' do
+  startup_type :disabled
+  action [:configure_startup, :stop]
+  only_if { ::Win32::Service.exists?('chef-client') }
 end


### PR DESCRIPTION
### Description

Along with disabling the service from stopping we should actually stop the windows chef-client service.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
