### PR TITLE
Fix missing log_dir attribute in task recipe for windows

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -24,7 +24,7 @@ class ::Chef::Recipe
 end
 
 # create a directory in case the log director does not exist
-directory 'C:\chef\log' do
+directory node['chef_client']['log_dir'] do
   inherits true
   recursive true
   action :create

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -59,6 +59,7 @@ action :add do
     frequency_modifier new_resource.frequency_modifier
     start_time         start_time_value
     start_day          new_resource.start_date unless new_resource.start_date.nil?
+    action             [ :create, :enable ]
   end
 end
 

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -59,7 +59,6 @@ action :add do
     frequency_modifier new_resource.frequency_modifier
     start_time         start_time_value
     start_day          new_resource.start_date unless new_resource.start_date.nil?
-    action             [ :create, :enable ]
   end
 end
 


### PR DESCRIPTION
### Description

This change fixes the missing attribute definition in the recipe task.rb for windows os.
Currently, the defined attribute for node['chef_client']['log_dir'] does not work in the task recipe, as it is missing.

### Issues Resolved

Fix missing log_dir attribute in task recipe for windows

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
Signed-off-by: Patrick Schaumburg <info@p-schaumburg.de>