### PR TITLE
Fix for specifying known path for cmd.exe on a windows system to avoid nefarious PATH settings

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -42,12 +42,15 @@ action :add do
   # Add custom options
   client_cmd << " #{new_resource.daemon_options.join(' ')}" if new_resource.daemon_options.any?
 
+  # Fetch path of cmd.exe through environment variable comspec
+  cmd_path = ENV['COMSPEC']
+
   # Between Chef Client 13.7 and 14.3 we required the command to be surrounded in single quotes
   # due to parsing problems with windows_task. Since 14.4 resolved we require double quotes around the command.
   full_command = if Gem::Requirement.new('< 13.7.0').satisfied_by?(Gem::Version.new(Chef::VERSION)) || Gem::Requirement.new('>= 14.4.0').satisfied_by?(Gem::Version.new(Chef::VERSION))
-                   "cmd /c \"#{client_cmd}\""
+                   "#{cmd_path} /c \"#{client_cmd}\""
                  else
-                   "cmd /c \'#{client_cmd}\'"
+                   "#{cmd_path} /c \'#{client_cmd}\'"
                  end
 
   windows_task new_resource.task_name do


### PR DESCRIPTION
Signed-off-by: vijaymmali1990 <vijay.mali@msystechnologies.com>

### Description
Replaced 'cmd' with the path of cmd.exe file to avoid nefarious PATH settings.
Instead of giving full path directly in the code we have taken the value of the path by using environment variable 'COMSPEC'

### Issues Resolved
Solves #601

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
