### PR TITLE
Changes systemd timer to trigger on OnActiveSec

### DIFF
--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -79,7 +79,7 @@ systemd_unit 'chef-client.timer' do
     'Install' => { 'WantedBy' => 'timers.target' },
     'Timer' => {
       'OnBootSec' => '1min',
-      'OnUnitActiveSec' => "#{node['chef_client']['interval']}sec",
+      'OnActiveSec' => "#{node['chef_client']['interval']}sec",
       'RandomizedDelaySec' => "#{node['chef_client']['splay']}sec",
     }
   )


### PR DESCRIPTION
### Description
When running chef-client via systemd timer, the chef-client.service unit
is of Type=oneshot. oneshot services don't enter an "active" state so
depending on "onUnitActiveSec" introduces issues where the timer will not
be scheduled to run.

This changes the timer to schedule relative to the moment the timer itself
is activated[1].

[1] https://www.freedesktop.org/software/systemd/man/systemd.timer.html#Options

Signed-off-by: ngharo <ngharo@gmail.com>

Motivation comes from [this comment from Lennart Poettering](https://github.com/systemd/systemd/issues/6680#issuecomment-326228938)
> hmm, so OnUnitActiveSec= operates relative to a unit becoming active, but Type=oneshot service units actually never become active, unless you combine them with RemainAfterExit=, hence the confusion...
> 
> Type=oneshot units after all do stuff during their start-up and when that's complete they go down again, they never stay up continiously... Hence, combining Type=oneshot with OnUnitActiveSec= can't really work... This is a big underdocumented though

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

