### PR TITLE
Fix order of conditional tests in client.rb.erb template

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -47,20 +47,20 @@ ohai.plugin_path << "<%= node["ohai"]["plugin_path"] %>"
 ohai.disabled_plugins = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]
 <% end -%>
 
-<% if !@start_handlers.empty? || !@report_handlers.empty? || !@exception_handlers.empty? -%>
+<% if !@start_handlers.nil? || !@report_handlers.nil? || !@exception_handlers.nil? -%>
 # Do not crash if a handler is missing / not installed yet
 begin
-<% unless @start_handlers.nil? -%>
+<% unless @start_handlers.empty? -%>
 <% @start_handlers.each do |handler| -%>
   start_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
 <% end -%>
 <% end -%>
-<% unless @report_handlers.nil? -%>
+<% unless @report_handlers.empty? -%>
 <% @report_handlers.each do |handler| -%>
   report_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
 <% end -%>
 <% end -%>
-<% unless @exception_handlers.nil? -%>
+<% unless @exception_handlers.empty? -%>
 <% @exception_handlers.each do |handler| -%>
   exception_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
 <% end -%>


### PR DESCRIPTION
### Description
Checks handlers for nil then empty, in that order. Prevents a blow up when handlers are indeed nil as seen in #611.

### Issues Resolved
Fixes #611 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
