### PR TITLE
Add support for `onstart` for Windows Scheduled task 

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -37,18 +37,10 @@ platforms:
       name: winrm
       elevated: true
     driver:
-      box: chef/windows-server-2016-standard # private box
-    transport:
-      name: winrm
-      elevated: true
-  - name: windows-2016
-    provisioner:
-      product_name: chef
-    transport:
-      name: winrm
-      elevated: true
-    driver:
-      box: tas50/windows-server-2016-standard # private box
+      box: tas50/windows_2016
+      gui: false
+      customize:
+        memory: 2048
     transport:
       name: winrm
       elevated: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -41,9 +41,6 @@ platforms:
       gui: false
       customize:
         memory: 2048
-    transport:
-      name: winrm
-      elevated: true
   - name: windows-2012r2-13
     provisioner:
       product_name: chef

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -53,13 +53,15 @@ action :add do
                    "#{cmd_path} /c \'#{client_cmd}\'"
                  end
 
+  # According to https://docs.microsoft.com/en-us/windows/desktop/taskschd/schtasks,
+  # the :once, :onstart, :onlogon, and :onidle schedules don't accept schedule modifiers
   windows_task new_resource.task_name do
     run_level :highest
-    command full_command
+    command   full_command
     user               new_resource.user
     password           new_resource.password
     frequency          new_resource.frequency.to_sym
-    frequency_modifier new_resource.frequency_modifier
+    frequency_modifier new_resource.frequency_modifier unless %w(once on_logon onstart on_idle).include?(new_resource.frequency)
     start_time         start_time_value
     start_day          new_resource.start_date unless new_resource.start_date.nil?
     action             [ :create, :enable ]

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -56,8 +56,8 @@ action :add do
   # According to https://docs.microsoft.com/en-us/windows/desktop/taskschd/schtasks,
   # the :once, :onstart, :onlogon, and :onidle schedules don't accept schedule modifiers
   windows_task new_resource.task_name do
-    run_level :highest
-    command   full_command
+    run_level          :highest
+    command            full_command
     user               new_resource.user
     password           new_resource.password
     frequency          new_resource.frequency.to_sym

--- a/test/cookbooks/test/recipes/task.rb
+++ b/test/cookbooks/test/recipes/task.rb
@@ -5,3 +5,14 @@ node.override['chef_client']['task']['start_date'] = Time.now.strftime('%m/%d/%Y
 include_recipe 'test::config'
 include_recipe 'chef-client::task'
 include_recipe 'chef-client::delete_validation'
+
+chef_client_scheduled_task 'Chef Client on start' do
+  user             node['chef_client']['task']['user']
+  password         node['chef_client']['task']['password']
+  frequency        'onstart'
+  config_directory node['chef_client']['conf_dir']
+  log_directory    node['chef_client']['log_dir']
+  chef_binary_path node['chef_client']['bin']
+  daemon_options   node['chef_client']['daemon_options']
+  task_name        "#{node['chef_client']['task']['name']}-onstart"
+end

--- a/test/integration/task/task_spec.rb
+++ b/test/integration/task/task_spec.rb
@@ -12,6 +12,6 @@ unless os.release.to_f == 6.1
   describe windows_task('chef-client') do
     it { should be_enabled }
     its('run_as_user') { should eq 'SYSTEM' }
-    its('task_to_run') { should match 'cmd /c C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300' }
+    its('task_to_run') { should match 'cmd.exe /c C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300' }
   end
 end

--- a/test/integration/task/task_spec.rb
+++ b/test/integration/task/task_spec.rb
@@ -14,4 +14,8 @@ unless os.release.to_f == 6.1
     its('run_as_user') { should eq 'SYSTEM' }
     its('task_to_run') { should match 'cmd.exe /c C:/opscode/chef/bin/chef-client -L C:/chef/log/client.log -c C:/chef/client.rb -s 300' }
   end
+
+  describe windows_task('chef-client-onstart') do
+    it { should be_enabled }
+  end
 end


### PR DESCRIPTION
### Description

This change allows the schedule type `onstart` for the Windows scheduled task for the Chef client

### Issues Resolved

closes #617 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- **N/A** New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>