### PR TITLE
Invert the conditional to be more accurate.

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -121,8 +121,9 @@ if node['chef_client']['cron']['use_cron_d']
     command cmd
   end
 else
-  # AIX does not support cron.d so we won't try to remove a cron_d resource.
-  unless node['platform_family'] == 'aix'
+  # Non-linux platforms don't support cron.d so we won't try to remove a cron_d resource.
+  # https://github.com/chef-cookbooks/cron/blob/master/resources/d.rb#L55
+  if node['os'] == 'linux'
     cron_d 'chef-client' do
       action :delete
     end


### PR DESCRIPTION
### Description

The conditional in the `cron` cookbook (which this still uses) uses `node['os']`, let's make the check match exactly.

### Issues Resolved

No open issue, but this causes it to fail on Solaris (among others).

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
