### PR TITLE
Use :restart instead of :reload action on macOS

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '11.1.2'
+version           '11.1.3'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::bsd_service', 'Configures chef-client as a service on *BSD'
 recipe 'chef-client::config', 'Configures the client.rb from a template.'

--- a/spec/unit/launchd_service_spec.rb
+++ b/spec/unit/launchd_service_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'chef-client::launchd_service' do
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(platform: 'mac_os_x', version: '10.14') do |node|
+    end.converge(described_recipe)
+  end
+
+  it 'creates the launch daemon' do
+    expect(chef_run).to create_template('/Library/LaunchDaemons/com.chef.chef-client.plist')
+  end
+
+  it 'reloads the launch daemon' do
+    expect(chef_run).to start_macosx_service('com.chef.chef-client')
+  end
+
+  it 'restarts the service when daemon is changed' do
+    expect(chef_run.template('/Library/LaunchDaemons/com.chef.chef-client.plist')).to notify('macosx_service[com.chef.chef-client]').to(:restart)
+  end
+end

--- a/templates/default/com.chef.chef-client.plist.erb
+++ b/templates/default/com.chef.chef-client.plist.erb
@@ -9,16 +9,16 @@
   <key>Program</key>
   <string><%= @client_bin %></string>
   <key>StartInterval</key>
-  <integer><%= node["chef_client"]["interval"] %></integer>
+  <integer><%= @interval %></integer>
   <key>RunAtLoad</key>
   <true/>
 <%- else %>
   <key>ProgramArguments</key>
   <array>
     <string><%= @client_bin %></string>
-    <string>-i <%= node["chef_client"]["interval"] %></string>
-    <string>-s <%= node["chef_client"]["splay"] %></string>
-    <% node["chef_client"]["daemon_options"].each do |option| -%>
+    <string>-i <%= @interval %></string>
+    <string>-s <%= @splay %></string>
+    <% @daemon_options.each do |option| -%>
     <string><%= option %></string>
     <% end -%>
   </array>
@@ -26,7 +26,7 @@
   <true/>
 <%- end %>
   <key>StandardOutPath</key>
-  <string><%= node["chef_client"]["log_dir"] %>/<%= node['chef_client']['log_file'] %></string>
+  <string><%= @log_dir %>/<%= @log_file %></string>
 </dict>
 
 </plist>


### PR DESCRIPTION
### Description

The main change here is to replace the `:reload` action with `:restart` since the former is not supported on macOS.

Additional changes:
- replaces inline attributes with instance variables to make the recipe easier to read
- uses the `macosx_service` resource explicitly in the recipe

### Issues Resolved

When using version 11.1.2 of the cookbook:

```
         * macosx_service[com.chef.chef-client] action reload
           * #<Chef::Provider::Service::Macosx:0x00007fae55a24030> does not support :reload
           ================================================================================
           Error executing action `reload` on resource 'macosx_service[com.chef.chef-client]'
           ================================================================================

           Chef::Exceptions::UnsupportedAction
           -----------------------------------
           #<Chef::Provider::Service::Macosx:0x00007fae55a24030> does not support :reload
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
