### PR TITLE
allow changing nice path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,7 @@ default['chef_client']['cron'] = {
   'append_log' => false,
   'use_cron_d' => false,
   'mailto' => nil,
+  'nice_path' => '/bin/nice',
 }
 
 # Configuration for chef-client::systemd_service recipe

--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -115,7 +115,7 @@ if node['chef_client']['cron']['use_cron_d']
     cmd = ''
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
     cmd << "#{env_vars} " if env_vars?
-    cmd << "/bin/nice -n #{process_priority} " if process_priority
+    cmd << "#{node['chef_client']['cron']['nice_path']} -n #{process_priority} " if process_priority
     cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1 "
     cmd << '|| echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
     command cmd


### PR DESCRIPTION
Added an attribute for changing the path of `nice` matching the currently hardcoded `/bin/nice`.

On Ubuntu 18.04:

```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.2 LTS"
```

```
#> which nice
/usr/bin/nice

#> ls /bin/nice
ls: cannot access '/bin/nice': No such file or directory
```

Thanks for looking at it @tas50 
