### PR TITLE
Expose ability to accept chef license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - CHEF_VERSION=14 INSTANCE=cron-centos-7
   - CHEF_VERSION=14 INSTANCE=delete-validation-ubuntu-1604
   - CHEF_VERSION=14 INSTANCE=delete-validation-centos-7
+  - CHEF_VERSION=14 INSTANCE=license-centos-7
   - CHEF_VERSION=14 INSTANCE=service-systemd-centos-7
   - CHEF_VERSION=14 INSTANCE=service-systemd-debian-8
   - CHEF_VERSION=14 INSTANCE=service-systemd-debian-9

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This cookbook makes use of attribute-driven configuration with this attribute. S
 
 [For the most current information about Chef Client configuration, read the documentation.](https://docs.chef.io/config_rb_client.html).
 
+- `node['chef_client']['license']` - Set to 'accept' or 'accept-no-persist' to accept the [license](https://docs.chef.io/chef_license.html) before upgrading to Chef 15.
 - `node['chef_client']['config']['chef_server_url']` - The URL for the Chef server.
 - `node['chef_client']['config']['validation_client_name']` - The name of the chef-validator key that is used by the chef-client to access the Chef server during the initial chef-client run.
 - `node['chef_client']['config']['verbose_logging']` - Set the log level. Options: true, nil, and false. When this is set to false, notifications about individual resources being processed are suppressed (and are output at the :info logging level). Setting this to false can be useful when a chef-client is run as a daemon. Default value: nil.
@@ -146,6 +147,8 @@ Use this recipe to run chef-client on Windows nodes as a scheduled task. Without
 Use the recipes as described above to configure your systems to run Chef as a service via cron / scheduled task or one of the service management systems supported by the recipes.
 
 The `chef-client::config` recipe is only _required_ with init style `init` (default setting for the attribute on debian/redhat family platforms, because the init script doesn't include the `pid_file` option which is set in the config.
+
+If you wish to accept the [Chef license](https://docs.chef.io/chef_license.html) before upgrading to Chef 15 you must use the `chef-client::config` recipe or set the `chef_license` value in your config manually. See [Accepting the Chef license](https://docs.chef.io/chef_license_accept.html) for more details or other ways to accept the license.
 
 The config recipe is used to dynamically generate the `/etc/chef/client.rb` config file. The template walks all attributes in `node['chef_client']['config']` and writes them out as key:value pairs. The key should be the configuration directive. For example, the following attributes (in a role):
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,9 @@ default['chef_client']['config'] = {
   'verify_api_cert' => true,
 }
 
+# Accept the chef license when running the chef service
+default['chef_client']['chef_license'] = nil
+
 # should the client fork on runs
 default['chef_client']['config']['client_fork'] = true
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -102,6 +102,10 @@ suites:
   run_list:
     - recipe[test::config]
 
+- name: license
+  run_list:
+    - recipe[test::license]
+
 - name: delete_validation
   run_list:
     - recipe[chef-client::delete_validation]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -109,6 +109,10 @@ suites:
     - recipe[test::config]
   excludes: ["windows-2012r2-13", "windows-2012r2-14", "windows-2016"]
 
+- name: license
+  run_list:
+    - recipe[test::license]
+
 # Test that the we can use the cron_d directory
 - name: use_cron_d
   run_list:

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -89,7 +89,7 @@ template "#{node['chef_client']['conf_dir']}/client.rb" do
     start_handlers: node['chef_client']['config']['start_handlers'],
     report_handlers: node['chef_client']['config']['report_handlers'],
     exception_handlers: node['chef_client']['config']['exception_handlers'],
-    chef_license: node['chef_client']['chef_license'],
+    chef_license: node['chef_client']['chef_license']
   )
 
   if node['chef_client']['reload_config']

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -88,7 +88,8 @@ template "#{node['chef_client']['conf_dir']}/client.rb" do
     ohai_disabled_plugins: node['ohai']['disabled_plugins'],
     start_handlers: node['chef_client']['config']['start_handlers'],
     report_handlers: node['chef_client']['config']['report_handlers'],
-    exception_handlers: node['chef_client']['config']['exception_handlers']
+    exception_handlers: node['chef_client']['config']['exception_handlers'],
+    chef_license: node['chef_client']['chef_license'],
   )
 
   if node['chef_client']['reload_config']

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -7,7 +7,7 @@ describe 'chef-client::config' do
 
   it 'does not accept the chef license by default' do
     expect(chef_run).to render_file('/etc/chef/client.rb') \
-      .with_content { |content| expect(content).to_not match(/chef_license/)}
+      .with_content { |content| expect(content).to_not match(/chef_license/) }
   end
 
   it 'contains the default chef_server_url setting' do
@@ -46,7 +46,7 @@ describe 'chef-client::config' do
   context 'Custom Attributes' do
     cached(:chef_run) do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-        node.normal['chef_client']['chef_license'] = "accept-no-persist"
+        node.normal['chef_client']['chef_license'] = 'accept-no-persist'
         node.normal['ohai']['disabled_plugins'] = [:passwd, 'dmi']
         node.normal['ohai']['plugin_path'] = '/etc/chef/ohai_plugins'
         node.normal['chef_client']['config']['log_level'] = ':debug'
@@ -63,7 +63,7 @@ describe 'chef-client::config' do
       end.converge(described_recipe)
     end
 
-    it "accepts the chef license" do
+    it 'accepts the chef license' do
       expect(chef_run).to render_file('/etc/chef/client.rb') \
         .with_content(/chef_license "accept-no-persist"/)
     end

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -12,7 +12,6 @@ end
 <% unless @chef_license.nil? -%>
 chef_license "<%= @chef_license %>"
 <% end -%>
-
 <% @chef_config.keys.sort.each do |option| -%>
   <% next if %w{ node_name exception_handlers report_handlers start_handlers http_proxy https_proxy no_proxy }.include?(option) -%>
   <% case option -%>

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -8,6 +8,11 @@
 end
 
 <% end -%>
+
+<% unless @chef_license.nil? -%>
+chef_license "<%= @chef_license %>"
+<% end -%>
+
 <% @chef_config.keys.sort.each do |option| -%>
   <% next if %w{ node_name exception_handlers report_handlers start_handlers http_proxy https_proxy no_proxy }.include?(option) -%>
   <% case option -%>

--- a/test/cookbooks/test/recipes/license.rb
+++ b/test/cookbooks/test/recipes/license.rb
@@ -1,2 +1,2 @@
-node.override['chef_client']['chef_license'] = "accept-no-persist"
+node.override['chef_client']['chef_license'] = 'accept-no-persist'
 include_recipe 'chef-client::config'

--- a/test/cookbooks/test/recipes/license.rb
+++ b/test/cookbooks/test/recipes/license.rb
@@ -1,0 +1,2 @@
+node.override['chef_client']['chef_license'] = "accept-no-persist"
+include_recipe 'chef-client::config'

--- a/test/integration/config/client_rb_spec.rb
+++ b/test/integration/config/client_rb_spec.rb
@@ -11,4 +11,5 @@ end
 describe file(config) do
   its('content') { should match(/ohai.disabled_plugins = \["Mdadm"\]/) }
   its('content') { should match(%r{ohai.plugin_path << "/tmp/kitchen/ohai/plugins"}) }
+  its('content') { should_not match(/chef_license/) }
 end

--- a/test/integration/license/client_rb_spec.rb
+++ b/test/integration/license/client_rb_spec.rb
@@ -1,0 +1,9 @@
+config = if os.windows?
+           'C:\chef\client.rb'
+         else
+           '/etc/chef/client.rb'
+         end
+
+describe file(config) do
+  its('content') { should match(/chef_license "accept-no-persist"/) }
+end


### PR DESCRIPTION
Adding ability to accept upcoming Chef license

### Description

This is a backwards compatible way to prepare for the upcoming Chef
license change. Set the attribute `node['chef_client']['chef_license'] =
'accept'` (or `'accept-no-persist'` if you do not want persistence and
will always specify this attribute) to accept the Chef license. When you
upgrade to Chef Client 15 the license will be automatically accepted and
there will not be any interruption to service.

Requires running the 'chef_client::config' recipe to work correctly. If
you do not run this recipe add `chef_license "accept"` to your client
config in whatever way you manage that.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
