### PR TITLE
Fix systemd unit transition from service to timer and vice-versa

### DIFF
--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -68,11 +68,6 @@ systemd_unit 'chef-client.service' do
   notifies(:restart, 'service[chef-client]', :delayed) unless timer
 end
 
-service 'chef-client' do
-  supports status: true, restart: true
-  action(timer ? [:disable, :stop] : [:enable, :start])
-end
-
 systemd_unit 'chef-client.timer' do
   content(
     'Unit' => { 'Description' => 'chef-client periodic run' },
@@ -85,4 +80,9 @@ systemd_unit 'chef-client.timer' do
   )
   action(timer ? [:create, :enable, :start] : [:stop, :disable, :delete])
   notifies :restart, to_s, :delayed unless timer
+end
+
+service 'chef-client' do
+  supports status: true, restart: true
+  action(timer ? [:disable, :stop] : [:enable, :start])
 end

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -84,5 +84,5 @@ systemd_unit 'chef-client.timer' do
     }
   )
   action(timer ? [:create, :enable, :start] : [:stop, :disable, :delete])
-  notifies :restart, to_s, :delayed
+  notifies :restart, to_s, :delayed unless timer
 end


### PR DESCRIPTION
### Description

This is not a common scenario, but I hit an issue when transitioning my Chef systemd config from a service to a timer: the chef-client service and the current process is terminated before setuping the timer.

When debugging the issue, I also tested the reverse scenario, transitioning from timer to service and I hit another bug: chef tries to restart the systemd_timer it has just removed.

This change fix above issues.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
