### PR TITLE
don't depend on cron cookbook anymore

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,9 +22,8 @@ recipe 'chef-client::upstart_service', 'Configures chef-client as a service unde
   supports os
 end
 
-depends 'cron', '>= 4.2.0'
 depends 'logrotate', '>= 1.9.0'
 
 source_url 'https://github.com/chef-cookbooks/chef-client'
 issues_url 'https://github.com/chef-cookbooks/chef-client/issues'
-chef_version '>= 13.0'
+chef_version '>= 14.0'


### PR DESCRIPTION
the cron resources are now provided by chef infra client 14 and later.

this change will get rid of these warnings when chef infra client 14 runs this cookbook:

WARN: Resource cron_access from the client is overriding the resource from a cookbook. Please upgrade your cookbook or remove the cookbook from your run_list.
[2019-06-19T04:11:25+00:00] WARN: Resource cron_access from the client is overriding the resource from a cookbook. Please upgrade your cookbook or remove the cookbook from your run_list.
[2019-06-19T04:11:25+00:00] WARN: Resource cron_manage from the client is overriding the resource from a cookbook. Please upgrade your cookbook or remove the cookbook from your run_list.
[2019-06-19T04:11:25+00:00] WARN: Resource cron_d from the client is overriding the resource from a cookbook. Please upgrade your cookbook or remove the cookbook from your run_list.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
