### PR TITLE
Release 11.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the chef-client cookbook.
 
+## 11.3.0 (2019-08-19)
+- Added KillMode option for systemd - [@kimbernator](https://github.com/kimbernator)
+
 ## 11.2.0 (2019-04-30)
 
 - Added the ability to accept upcoming Chef 15+ license via attribute - [@tyler-ball](https://github.com/tyler-ball)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Manages client.rb configuration and chef-client service'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '11.2.0'
+version           '11.3.0'
 recipe 'chef-client', 'Includes the service recipe by default.'
 recipe 'chef-client::bsd_service', 'Configures chef-client as a service on *BSD'
 recipe 'chef-client::config', 'Configures the client.rb from a template.'


### PR DESCRIPTION
Signed-off-by: Matthew Newell <matthew.newell@cerner.com>

### Description

This change performs the necessary version bump for the release of 11.3.0 containing the systemd KillMode additions from #629 

### Issues Resolved

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
