### PR TITLE
Fix for nil class error if chef client handlers are not defined.

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -51,25 +51,26 @@ ohai.plugin_path << "<%= node["ohai"]["plugin_path"] %>"
 ohai.disabled_plugins = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]
 <% end -%>
 
-<% if !@start_handlers.empty? || !@report_handlers.empty? || !@exception_handlers.empty? -%>
 # Do not crash if a handler is missing / not installed yet
 begin
-<% unless @start_handlers.nil? -%>
-<% @start_handlers.each do |handler| -%>
-  start_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
+<% if @start_handlers.is_a?(Array) && !@start_handlers.empty? -%>
+  <% @start_handlers.each do |handler| -%>
+    start_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
+  <% end -%>
 <% end -%>
+
+<% if @report_handlers.is_a?(Array) && !@report_handlers.empty? -%>
+  <% @report_handlers.each do |handler| -%>
+    report_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
+  <% end -%>
 <% end -%>
-<% unless @report_handlers.nil? -%>
-<% @report_handlers.each do |handler| -%>
-  report_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
-<% end -%>
-<% end -%>
-<% unless @exception_handlers.nil? -%>
-<% @exception_handlers.each do |handler| -%>
-  exception_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
-<% end -%>
+
+<% if @exception_handlers.is_a?(Array) && !@exception_handlers.empty? -%>
+  <% @exception_handlers.each do |handler| -%>
+    exception_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
+  <% end -%>
 <% end -%>
 rescue NameError => e
   Chef::Log.error e
 end
-<% end -%>
+

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -53,19 +53,19 @@ ohai.disabled_plugins = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.g
 
 # Do not crash if a handler is missing / not installed yet
 begin
-<% if @start_handlers.is_a?(Array) && !@start_handlers.empty? -%>
+<% if @start_handlers.is_a?(Array) -%>
   <% @start_handlers.each do |handler| -%>
     start_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
   <% end -%>
 <% end -%>
 
-<% if @report_handlers.is_a?(Array) && !@report_handlers.empty? -%>
+<% if @report_handlers.is_a?(Array) -%>
   <% @report_handlers.each do |handler| -%>
     report_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
   <% end -%>
 <% end -%>
 
-<% if @exception_handlers.is_a?(Array) && !@exception_handlers.empty? -%>
+<% if @exception_handlers.is_a?(Array) -%>
   <% @exception_handlers.each do |handler| -%>
     exception_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
   <% end -%>


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
If user sets chef-client configuration attributes in the following format in his cookbook 
```
default['chef_client']['config'] = {
  rubygems_url: 'https://example.com'
}
```
it results into the ```undefined method empty? for NilClass ``` error as mentioned in the issue #611 

Reason is above value overrides default attributes due to which handlers are set to nil, which results in failing of empty? check for handlers and throws above mentioned error.

Chef handlers configuration should be defined in array as mentioned in the [Readme](https://github.com/chef-cookbooks/chef-client#start-report-exception-handlers). I have added the class check i.e. Array and removed the unwanted code.

Taken care of #612 
### Issues Resolved
#611 
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
