### PR TITLE
Fix chef-client.service reload when systemd-timer is setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['log_dir']` - Sets directory used to store chef-client logs. Default "/var/log/chef".
 - `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.
 - `node['chef_client']['log_rotation']['prerotate']` - Set prerotate action for chef-client logrotation. Default to `nil`.
-- `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system.
+- `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system. It should be empty to skip reloading chef-client service in case if `node['chef_client']['systemd']['timer']` is true.
 - `node['chef_client']['conf_dir']` - Sets directory used via command-line option to a location where chef-client search for the client config file . Default "/etc/chef".
 - `node['chef_client']['bin']` - Sets the full path to the `chef-client` binary. Mainly used to set a specific path if multiple versions of chef-client exist on a system or the bin has been installed in a non-sane path. Default "/usr/bin/chef-client".
 - `node['chef_client']['ca_cert_path']` - Sets the full path to the PEM-encoded certificate trust store used by `chef-client` when daemonized. If not set, [default values](https://docs.chef.io/chef_client_security.html#ssl-cert-file) are used.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -175,10 +175,8 @@ end
 default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil
 default['chef_client']['log_rotation']['postrotate'] =  case node['chef_client']['init_style']
-                                                        when 'systemd' && node['chef_client']['systemd']['timer']
-                                                          ''
                                                         when 'systemd'
-                                                          'systemctl reload chef-client.service >/dev/null || :'
+                                                          node['chef_client']['systemd']['timer'] ? '' : 'systemctl reload chef-client.service >/dev/null || :'
                                                         when 'upstart'
                                                           'initctl reload chef-client >/dev/null || :'
                                                         else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -175,6 +175,8 @@ end
 default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil
 default['chef_client']['log_rotation']['postrotate'] =  case node['chef_client']['init_style']
+                                                        when 'systemd' && node['chef_client']['systemd']['timer']
+                                                          ''
                                                         when 'systemd'
                                                           'systemctl reload chef-client.service >/dev/null || :'
                                                         when 'upstart'


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description


As per issue : logrotation is installed but tries to reload the chef-client.service unit on postrotate which is not active: `chef-client.service is not active, cannot reload.` While `|| : ` always returns a successful exit status. So When systemd-timer setup is used, the logrotate task should just skip the reloading defined in https://github.com/chef-cookbooks/chef-client/blob/4ee4d1c3231b1e8add506aec47a461e534d85a85/attributes/default.rb#L176

### Issues Resolved

Fixes https://github.com/chef-cookbooks/chef-client/issues/559


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
