### PR TITLE
Specify OPTIONS in /etc/defaults for Debian

### DIFF
--- a/templates/default/debian/default/chef-client.erb
+++ b/templates/default/debian/default/chef-client.erb
@@ -1,3 +1,4 @@
 CONFIG=<%= node["chef_client"]["conf_dir"] %>/client.rb
 INTERVAL=<%= node["chef_client"]["interval"] %>
 SPLAY=<%= node["chef_client"]["splay"] %>
+OPTIONS="<%= node["chef_client"]["daemon_options"].join(' ') %>"


### PR DESCRIPTION
### Description
Specify OPTIONS in /etc/defaults for Debian systems

### Issues Resolved

I am running with systemd on Ubuntu 18.04.
`node['chef_client']['daemon_options']` does not appear to be respected in this scenerio.

I suspect the problem is that OPTIONS is not written to `/etc/default/chef-config`, although it is [being read](https://github.com/chef-cookbooks/chef-client/blob/7b01bb3665bdc6c58e043afc3fa3e09a6e518625/recipes/systemd_service.rb#L25) by the systemd unit file.
The [redhat/sysconfig version](https://github.com/chef-cookbooks/chef-client/blob/7b01bb3665bdc6c58e043afc3fa3e09a6e518625/templates/default/redhat/sysconfig/chef-client.erb#L14) does appear to set the option.

Is there a reason we can't just copy it over?
Example PR to do so. Tests still pass.
Adding OPTIONS to this file locally appears to give me the desired behaviour.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
