### PR TITLE
Use random_delay from windows_task for splay

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [USAGE](#usage).
 The following attributes affect the behavior of the chef-client program when running as a service through one of the service recipes, or in cron with the cron recipe, or are used in the recipes for various settings that require flexibility.
 
 - `node['chef_client']['interval']` - Sets `Chef::Config[:interval]` via command-line option for number of seconds between chef-client daemon runs. Default 1800.
-- `node['chef_client']['splay']` - Sets `Chef::Config[:splay]` via command-line option for a random amount of seconds to add to interval. Default 300.
+- `node['chef_client']['splay']` - Sets `Chef::Config[:splay]` via command-line option for a random amount of seconds to add to interval. On windows, this value is used for the scheduled task's random delay. Default 300.
 - `node['chef_client']['log_file']` - Sets the file name used to store chef-client logs. Default "client.log".
 - `node['chef_client']['log_dir']` - Sets directory used to store chef-client logs. Default "/var/log/chef".
 - `node['chef_client']['log_rotation']['options']` - Set options to logrotation of chef-client log file. Default `['compress']`.

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -37,7 +37,6 @@ action :add do
   client_cmd = new_resource.chef_binary_path.dup
   client_cmd << " -L #{::File.join(new_resource.log_directory, node['chef_client']['log_file'])}" unless node['chef_client']['log_file'].nil?
   client_cmd << " -c #{::File.join(new_resource.config_directory, 'client.rb')}"
-  client_cmd << " -s #{new_resource.splay}"
 
   # Add custom options
   client_cmd << " #{new_resource.daemon_options.join(' ')}" if new_resource.daemon_options.any?
@@ -64,6 +63,7 @@ action :add do
     frequency_modifier new_resource.frequency_modifier unless %w(once on_logon onstart on_idle).include?(new_resource.frequency)
     start_time         start_time_value
     start_day          new_resource.start_date unless new_resource.start_date.nil?
+    random_delay       new_resource.splay
     action             [ :create, :enable ]
   end
 end


### PR DESCRIPTION
Signed-off-by: Jeremy Kimber <jeremy.kimber@cerner.com>

### Description

During some testing today, I realized that the splay option I was defining didn't actually have any impact on my windows nodes. It turns out that the `-s` parameter for chef-client does not have any effect unless forking is enabled, and forking does not work for windows (it can be enabled, allowing splay to take effect, but the process will not fork). In short, splay requires enabling a broken function that is not obviously connected to it or documented as being required.

Since this cookbook now uses a scheduled task instead of a service on windows, it makes me wonder what the value of a splay is in the command line when the `windows_task` resource has a `random_delay` property which has the same functionality and accepts the exact same data (String or integer of the upper limit, in seconds, to randomly delay execution). Utilization of this property would mean:

- Forking no longer needs to be enabled
- Manual executions of the scheduled task would no longer include a random delay if forking is enabled.

I'm hoping to get some people to weigh in on how significant this change is or if there are impacts this might have that I'm unaware of.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
