### PR TITLE
Additional space removed from cron recipe

### DIFF
--- a/recipes/cron.rb
+++ b/recipes/cron.rb
@@ -116,8 +116,8 @@ if node['chef_client']['cron']['use_cron_d']
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
     cmd << "#{env_vars} " if env_vars?
     cmd << "#{node['chef_client']['cron']['nice_path']} -n #{process_priority} " if process_priority
-    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1 "
-    cmd << '|| echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
+    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1"
+    cmd << ' || echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
     command cmd
   end
 else
@@ -140,8 +140,8 @@ else
     cmd << "/bin/sleep #{sleep_time}; " if sleep_time
     cmd << "#{env_vars} " if env_vars?
     cmd << "#{node['chef_client']['cron']['nice_path']} -n #{process_priority} " if process_priority
-    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1 "
-    cmd << '|| echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
+    cmd << "#{client_bin} #{daemon_options}#{append_log} #{log_file} 2>&1"
+    cmd << ' || echo "Chef client execution failed"' if node['chef_client']['cron']['mailto']
     command cmd
   end
 end


### PR DESCRIPTION
Signed-off-by: sanga17 <sausekar@msystechnologies.com>

### Description

Additional space was added at the end of string in the cron which is handled at the beginning of next string of command. 

### Issues Resolved

Fixes: https://github.com/chef-cookbooks/chef-client/issues/623

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
