### PR TITLE
Add file_staging_uses_destdir to client.rb/attributes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 - `node['chef_client']['run_path']` - Directory location where chef-client should write the PID file. Default based on platform, falls back to "/var/run".
 - `node['chef_client']['cache_path']` - Directory location for `Chef::Config[:file_cache_path]` where chef-client will cache various files. Default is based on platform, falls back to "/var/chef/cache".
 - `node['chef_client']['backup_path']` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
+- `node['chef_client']['file_staging_uses_destdir']` - How file staging (via temporary files) is done. When true, temporary files are created in the directory in which files will reside. When false, temporary files are created under ENV['TMP']. Default value: true.
+This cookbook makes use of attribute-driven configuration with this attribute. See [USAGE](#usage) for examples.
 - `node['chef_client']['launchd_mode']` - (Only for Mac OS X) if set to `'daemon'`, runs chef-client with `-d` and `-s` options; defaults to `'interval'`.
 - When `chef_client['log_file']` is set and running on a [logrotate](https://supermarket.chef.io/cookbooks/logrotate) supported platform (debian, rhel, fedora family), use the following attributes to tune log rotation.
   - `node['chef_client']['logrotate']['rotate']` - Number of rotated logs to keep on disk, default 12.
   - `node['chef_client']['logrotate']['frequency']` - How often to rotate chef client logs, default weekly.
-- `node['chef_client']['file_staging_uses_destdir']` - How file staging (via temporary files) is done. When true, temporary files are created in the directory in which files will reside. When false, temporary files are created under ENV['TMP']. Default value: true.
-This cookbook makes use of attribute-driven configuration with this attribute. See [USAGE](#usage) for examples.
 
 - `node['chef_client']['config']` - A hash of Chef::Config keys and their values, rendered dynamically in `/etc/chef/client.rb`.
 - `node['chef_client']['load_gems']` - Hash of gems to load into chef via the client.rb file

--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 - `node['chef_client']['backup_path']` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
 - `node['chef_client']['launchd_mode']` - (Only for Mac OS X) if set to `'daemon'`, runs chef-client with `-d` and `-s` options; defaults to `'interval'`.
 - When `chef_client['log_file']` is set and running on a [logrotate](https://supermarket.chef.io/cookbooks/logrotate) supported platform (debian, rhel, fedora family), use the following attributes to tune log rotation.
-
   - `node['chef_client']['logrotate']['rotate']` - Number of rotated logs to keep on disk, default 12.
   - `node['chef_client']['logrotate']['frequency']` - How often to rotate chef client logs, default weekly.
-
+- `node['chef_client']['file_staging_uses_destdir']` - How file staging (via temporary files) is done. When true, temporary files are created in the directory in which files will reside. When false, temporary files are created under ENV['TMP']. Default value: true.
 This cookbook makes use of attribute-driven configuration with this attribute. See [USAGE](#usage) for examples.
 
 - `node['chef_client']['config']` - A hash of Chef::Config keys and their values, rendered dynamically in `/etc/chef/client.rb`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -173,6 +173,9 @@ else
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
 end
 
+# Need to set this Option in client.rb
+default['chef_client']['file_staging_uses_destdir'] = true
+
 # Must appear after init_style to take effect correctly
 default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -79,3 +79,6 @@ file_cache_path "<%= node['chef_client']['file_cache_path'] %>"
 <% unless node['chef_client']['file_backup_path'].nil? -%>
 file_backup_path "<%= node['chef_client']['file_backup_path'] %>"
 <% end -%>
+<% unless node['chef_client']['file_staging_uses_destdir'].nil? -%>
+file_staging_uses_destdir "<%= node['chef_client']['file_staging_uses_destdir'] %>"
+<% end -%>


### PR DESCRIPTION
### Description

Add the option 'file_staging_uses_destdir' to be able to set this by the chef-client::config / attribute recipe in client.rb. 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
