### PR TITLE
Make sure to create the log directory

### DIFF
--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -1,9 +1,9 @@
 #
 # Author:: Paul Mooring (<paul@chef.io>)
-# Cookbook::  chef
+# Cookbook:: chef-client
 # Recipe:: task
 #
-# Copyright:: 2011-2019, Chef Software, Inc.
+# Copyright:: 2011-2020, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,13 +21,6 @@
 # include helper methods
 class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
-end
-
-# create a directory in case the log director does not exist
-directory node['chef_client']['log_dir'] do
-  inherits true
-  recursive true
-  action :create
 end
 
 # libraries/helpers.rb method to DRY directory creation resources

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-client
 # resource:: chef_client_scheduled_task
 #
-# Copyright:: 2017-2019, Chef Software, Inc.
+# Copyright:: 2017-2020, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +34,13 @@ property :daemon_options, Array, default: []
 property :task_name, String, default: 'chef-client'
 
 action :add do
+  # create a directory in case the log director does not exist
+  directory new_resource.log_directory do
+    inherits true
+    recursive true
+    action :create
+  end
+
   # Build command line to pass to cmd.exe
   client_cmd = new_resource.chef_binary_path.dup
   client_cmd << " -L #{::File.join(new_resource.log_directory, new_resource.log_file_name)}"


### PR DESCRIPTION
We're using the log directory in the scheduled task so we should make sure it exists. The recipe did that previously, but the resource should actually handle that behavior.

Signed-off-by: Tim Smith <tsmith@chef.io>