### PR TITLE
chef_client_cron: Don't cleanup legacy cron entries

### DIFF
--- a/resources/cron.rb
+++ b/resources/cron.rb
@@ -53,10 +53,6 @@ action :remove do
   cron_d new_resource.job_name do
     action :delete
   end
-
-  cron new_resource.job_name do
-    action :delete
-  end
 end
 
 action_class do


### PR DESCRIPTION
We manage cron_d and not crontab so let's just leave these alone. It might make sense in the future, but for now let's just assume clean installs or legacy installs are cleaned up on their own.

Signed-off-by: Tim Smith <tsmith@chef.io>