### PR TITLE
Update the task recipe to use the log_file attribute

### DIFF
--- a/test/cookbooks/test/recipes/task.rb
+++ b/test/cookbooks/test/recipes/task.rb
@@ -12,6 +12,7 @@ chef_client_scheduled_task 'Chef Client on start' do
   frequency        'onstart'
   config_directory node['chef_client']['conf_dir']
   log_directory    node['chef_client']['log_dir']
+  log_file_name    node['chef_client']['log_file']
   chef_binary_path node['chef_client']['bin']
   daemon_options   node['chef_client']['daemon_options']
   task_name        "#{node['chef_client']['task']['name']}-onstart"


### PR DESCRIPTION
Pass the attribute into the resource. Previously the resource used this attribute directly. This maintains the previous behavior for recipe users.

Signed-off-by: Tim Smith <tsmith@chef.io>