### PR TITLE
Remove support for Debian/SUSE/Fedora in init_service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,3 @@ before_script:
   - chef --version
 
 script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml CHEF_VERSION=${CHEF_VERSION} kitchen verify ${INSTANCE}
-
-matrix:
-  include:
-    - script:
-      - delivery local all
-      env:
-        - UNIT_AND_LINT=1
-        - CHEF_LICENSE=accept

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -79,12 +79,12 @@ suites:
 - name: service_init
   run_list:
     - recipe[test::service]
-  includes: ["centos-6", "amazon-linux", "sles-12-sp1"]
+  includes: ["centos-6", "amazon-linux"]
 
 - name: service_systemd
   run_list:
     - recipe[test::service]
-  includes: ["centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "opensuse-leap-15"]
+  includes: ["centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "opensuse-leap-15", "sles-12-sp1"]
 
 - name: service_smf
   run_list:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -31,7 +31,6 @@ platforms:
       box: chef/solaris-11.3 # private box
   - name: ubuntu-16.04
   - name: ubuntu-18.04
-  - name: ubuntu-18.10
   - name: ubuntu-19.04
   - name: windows-2019
     transport:
@@ -84,7 +83,7 @@ suites:
 - name: service_systemd
   run_list:
     - recipe[test::service]
-  includes: ["centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "opensuse-leap-15", "sles-12-sp1"]
+  includes: ["amazonlinux-2", "centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-19.04", "opensuse-leap-15", "sles-12-sp1"]
 
 - name: service_smf
   run_list:
@@ -108,7 +107,7 @@ suites:
     chef_client:
       systemd:
         timer: true
-  includes: ["centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "opensuse-leap-15"]
+  includes: ["amazonlinux-2", "centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-19.04", "opensuse-leap-15", "sles-12-sp1"]
 
 - name: config
   run_list:

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -1,3 +1,5 @@
+raise "The chef_client::init_service recipe only supports RHEL / Amazon platform families. All other platforms should run chef-client as a service using systemd or a scheduled job using cron / systemd timers." unless platform_family?('rhel', 'amazon')
+
 # include helper methods
 class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
@@ -9,14 +11,8 @@ Chef::Log.debug("Using chef-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 
-dist_dir, conf_dir = value_for_platform_family(
-  %w(amazon rhel fedora) => %w( redhat sysconfig ),
-  %w(debian) => %w( debian default ),
-  %w(suse) => %w( suse sysconfig )
-)
-
 template '/etc/init.d/chef-client' do
-  source "#{dist_dir}/init.d/chef-client.erb"
+  source "redhat/init.d/chef-client.erb"
   mode '0755'
   variables(client_bin: client_bin,
             chkconfig_start_order: node['chef_client']['chkconfig']['start_order'],
@@ -24,8 +20,8 @@ template '/etc/init.d/chef-client' do
   notifies :restart, 'service[chef-client]', :delayed
 end
 
-template "/etc/#{conf_dir}/chef-client" do
-  source "#{dist_dir}/#{conf_dir}/chef-client.erb"
+template "/etc/sysconfig/chef-client" do
+  source "redhat/sysconfig/chef-client.erb"
   mode '0644'
   notifies :restart, 'service[chef-client]', :delayed
 end

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -1,4 +1,4 @@
-raise "The chef_client::init_service recipe only supports RHEL / Amazon platform families. All other platforms should run chef-client as a service using systemd or a scheduled job using cron / systemd timers." unless platform_family?('rhel', 'amazon')
+raise 'The chef_client::init_service recipe only supports RHEL / Amazon platform families. All other platforms should run chef-client as a service using systemd or a scheduled job using cron / systemd timers.' unless platform_family?('rhel', 'amazon')
 
 # include helper methods
 class ::Chef::Recipe
@@ -12,7 +12,7 @@ node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 
 template '/etc/init.d/chef-client' do
-  source "redhat/init.d/chef-client.erb"
+  source 'redhat/init.d/chef-client.erb'
   mode '0755'
   variables(client_bin: client_bin,
             chkconfig_start_order: node['chef_client']['chkconfig']['start_order'],
@@ -20,8 +20,8 @@ template '/etc/init.d/chef-client' do
   notifies :restart, 'service[chef-client]', :delayed
 end
 
-template "/etc/sysconfig/chef-client" do
-  source "redhat/sysconfig/chef-client.erb"
+template '/etc/sysconfig/chef-client' do
+  source 'redhat/sysconfig/chef-client.erb'
   mode '0644'
   notifies :restart, 'service[chef-client]', :delayed
 end


### PR DESCRIPTION
None of these platforms have a currently supported distro that doesn't ship with systemd support.

Signed-off-by: Tim Smith <tsmith@chef.io>