### PR TITLE
Set the default *nix path to chef-client to /opt/chef/bin/chef-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following attributes affect the behavior of the chef-client program when run
 - `node['chef_client']['log_rotation']['prerotate']` - Set prerotate action for chef-client logrotation. Default to `nil`.
 - `node['chef_client']['log_rotation']['postrotate']` - Set postrotate action for chef-client logrotation. Default to chef-client service reload depending on init system. It should be empty to skip reloading chef-client service in case if `node['chef_client']['systemd']['timer']` is true.
 - `node['chef_client']['conf_dir']` - Sets directory used via command-line option to a location where chef-client search for the client config file . Default "/etc/chef".
-- `node['chef_client']['bin']` - Sets the full path to the `chef-client` binary. Mainly used to set a specific path if multiple versions of chef-client exist on a system or the bin has been installed in a non-sane path. Default "/usr/bin/chef-client".
+- `node['chef_client']['bin']` - Sets the full path to the `chef-client` binary. Mainly used to set a specific path if multiple versions of chef-client exist on a system or the bin has been installed in a non-sane path. Default "/opt/chef/bin/chef-client".
 - `node['chef_client']['ca_cert_path']` - Sets the full path to the PEM-encoded certificate trust store used by `chef-client` when daemonized. If not set, [default values](https://docs.chef.io/chef_client_security.html#ssl-cert-file) are used.
 - `node['chef_client']['cron']['minute']` - The minute that chef-client will run as a cron task. See [cron recipe](#cron)
 - `node['chef_client']['cron']['hour']` - The hour that chef-client will run as a cron task. See [cron recipe](#cron)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,7 +37,7 @@ default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
 default['chef_client']['conf_dir']    = '/etc/chef'
-default['chef_client']['bin']         = '/usr/bin/chef-client'
+default['chef_client']['bin']         = '/opt/chef/bin/chef-client'
 
 # Set a sane default log directory location, overriden by specific
 # platforms below.


### PR DESCRIPTION
Use the omnibus path instead of relying on paths and which to find the path.

Signed-off-by: Tim Smith <tsmith@chef.io>