### PR TITLE
Reintroduce rescue around handlers initialization

### DIFF
--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -56,22 +56,37 @@ ohai.disabled_plugins = [<%= @ohai_disabled_plugins.map { |k| k.match(/:/) ? k.g
 ohai.optional_plugins = [<%= @ohai_optional_plugins.map { |k| k.match(/:/) ? k.gsub(/^:/, '').to_sym.inspect : k.inspect }.join(",") %>]
 <% end -%>
 
-<% if @start_handlers.is_a?(Array) -%>
+<% if @start_handlers.is_a?(Array) && @start_handlers.any? -%>
+  # Do not crash if a start handler is missing / not installed yet
+  begin
   <% @start_handlers.each do |handler| -%>
     start_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
   <% end -%>
+  rescue NameError => e
+    Chef::Log.error e
+  end
 <% end -%>
 
-<% if @report_handlers.is_a?(Array) -%>
+<% if @report_handlers.is_a?(Array) && @report_handlers.any? -%>
+  # Do not crash if a report handler is missing / not installed yet
+  begin
   <% @report_handlers.each do |handler| -%>
     report_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
   <% end -%>
+  rescue NameError => e
+    Chef::Log.error e
+  end
 <% end -%>
 
-<% if @exception_handlers.is_a?(Array) -%>
+<% if @exception_handlers.is_a?(Array) && @exception_handlers.any? -%>
+  # Do not crash if an exception handler is missing / not installed yet
+  begin
   <% @exception_handlers.each do |handler| -%>
     exception_handlers << <%= handler["class"] %>.new(<%= handler["arguments"].join(',') %>)
   <% end -%>
+  rescue NameError => e
+    Chef::Log.error e
+  end
 <% end -%>
 <% unless node['chef_client']['file_cache_path'].nil? -%>
 file_cache_path "<%= node['chef_client']['file_cache_path'] %>"


### PR DESCRIPTION
Formelery it used to be a single rescue around all handlers init, but it has been removed (in #645) to avoid un-needed code when no handlers defined (#646).

Setup one begin rescue block per handler init, only if required.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
