### PR TITLE
Initial take at a chef_client_systemd_timer resource

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -85,6 +85,11 @@ suites:
     - recipe[test::service]
   includes: ["amazonlinux-2", "centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-19.04", "opensuse-leap-15", "sles-12-sp1"]
 
+- name: systemd_timer_resource
+  run_list:
+    - recipe[test::systemd_timer_resource]
+  includes: ["amazonlinux-2", "centos-7", "centos-8", "debian-9", "debian-10", "fedora-latest", "ubuntu-16.04", "ubuntu-18.04", "ubuntu-19.04", "opensuse-leap-15", "sles-12-sp1"]
+
 - name: service_smf
   run_list:
     - recipe[test::service]

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -1,0 +1,118 @@
+#
+# Cookbook:: chef-client
+# resource:: chef_client_systemd_timer
+#
+# Copyright:: 2020, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+resource_name :chef_client_systemd_timer
+
+property :user, String, default: 'root'
+
+property :job_name, String, default: 'chef-client'
+property :delay_after_boot, String, default: '1min'
+property :interval, String, default: '30min'
+
+property :splay, [Integer, String], default: 300,
+                                    coerce: proc { |x| Integer(x) },
+                                    callbacks: { 'should be a positive number' => proc { |v| v > 0 } }
+
+property :description, String, default: 'Chef Infra Client periodic execution'
+
+property :log_directory, String, default: '/var/log/chef'
+property :log_file_name, String, default: 'client.log'
+property :chef_binary_path, String, default: '/opt/chef/bin/chef-client'
+property :daemon_options, Array, default: []
+
+action :add do
+  unless ::Dir.exist?(new_resource.log_directory)
+    directory new_resource.log_directory do
+      owner new_resource.user
+      mode '0640'
+      recursive true
+    end
+  end
+
+  systemd_unit "#{new_resource.job_name}.service" do
+    content service_content
+    action :create
+  end
+
+  systemd_unit "#{new_resource.job_name}.timer" do
+    content timer_content
+    action [:create, :enable, :start]
+  end
+end
+
+action :remove do
+  systemd_unit "#{new_resource.job_name}.service" do
+    action :remove
+  end
+
+  systemd_unit "#{new_resource.job_name}.timer" do
+    action :remove
+  end
+end
+
+action_class do
+  #
+  # The chef-client command to run in the systemd unit.
+  #
+  # @return [String]
+  #
+  def chef_client_cmd
+    cmd = "#{new_resource.chef_binary_path} "
+    cmd << "#{new_resource.daemon_options.join(' ')} " unless new_resource.daemon_options.empty?
+    cmd << "-L #{::File.join(new_resource.log_directory, new_resource.log_file_name)}"
+    cmd
+  end
+
+  #
+  # The timer content to pass to the systemd_unit
+  #
+  # @return [Hash]
+  #
+  def timer_content
+    {
+    'Unit' => { 'Description' => new_resource.description },
+    'Timer' => {
+      'OnBootSec' => new_resource.delay_after_boot,
+      'OnUnitActiveSec' => new_resource.interval,
+      'RandomizedDelaySec' => new_resource.splay,
+      },
+    'Install' => { 'WantedBy' => 'timers.target' },
+    }
+  end
+
+  #
+  # The service content to pass to the systemd_unit
+  #
+  # @return [Hash]
+  #
+  def service_content
+    {
+      'Unit' => {
+        'Description' => new_resource.description,
+        'After' => 'network.target auditd.service',
+      },
+      'Service' => {
+        'Type' => 'oneshot',
+        'ExecStart' => chef_client_cmd,
+        'SuccessExitStatus' => 3,
+      },
+      'Install' => { 'WantedBy' => 'multi-user.target' },
+    }
+  end
+end

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -30,6 +30,7 @@ property :splay, [Integer, String], default: 300,
                                     callbacks: { 'should be a positive number' => proc { |v| v > 0 } }
 
 property :description, String, default: 'Chef Infra Client periodic execution'
+property :run_on_battery, [true, false], default: true
 
 property :log_directory, String, default: '/var/log/chef'
 property :log_file_name, String, default: 'client.log'
@@ -102,7 +103,7 @@ action_class do
   # @return [Hash]
   #
   def service_content
-    {
+    unit = {
       'Unit' => {
         'Description' => new_resource.description,
         'After' => 'network.target auditd.service',
@@ -114,5 +115,9 @@ action_class do
       },
       'Install' => { 'WantedBy' => 'multi-user.target' },
     }
+
+    unit['Service']['ConditionACPower'] = 'true' unless new_resource.run_on_battery
+
+    unit
   end
 end

--- a/test/cookbooks/test/recipes/systemd_timer_resource.rb
+++ b/test/cookbooks/test/recipes/systemd_timer_resource.rb
@@ -1,0 +1,3 @@
+chef_client_systemd_timer 'schedule chef-client to run as cron job' do
+  daemon_options ['--run-lock-timeout 0', '--chef-license accept']
+end


### PR DESCRIPTION
Make it super simple to configure chef-client to run as a systemd-timer.

Signed-off-by: Tim Smith <tsmith@chef.io>