### PR TITLE
Add a dist option to support community branches

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,12 +39,12 @@ default['chef_client']['chef_license'] = nil
 default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
-default['chef_client']['conf_dir']    = "/etc/chef"
-default['chef_client']['bin']         = "/opt/chef/bin/chef-client"
+default['chef_client']['conf_dir']    = '/etc/chef'
+default['chef_client']['bin']         = '/opt/chef/bin/chef-client'
 
 # Set a sane default log directory location, overriden by specific
 # platforms below.
-default['chef_client']['log_dir']     = "/var/log/chef"
+default['chef_client']['log_dir']     = '/var/log/chef'
 
 # If log file is used, default permissions so everyone can read
 default['chef_client']['log_perm'] = '640'
@@ -80,7 +80,7 @@ default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for non-system users
 default['chef_client']['task']['start_time'] = nil
 default['chef_client']['task']['start_date'] = nil
-default['chef_client']['task']['name'] = "chef-client"
+default['chef_client']['task']['name'] = 'chef-client'
 
 default['chef_client']['load_gems'] = {}
 
@@ -117,28 +117,28 @@ case node['platform_family']
 when 'aix'
   default['chef_client']['init_style']  = 'src'
   default['chef_client']['svc_name']    = node['chef_client']['dist']
-  default['chef_client']['run_path']    = "/var/run/chef"
-  default['chef_client']['file_cache_path'] = "/var/spool/chef"
-  default['chef_client']['file_backup_path'] = "/var/lib/chef"
-  default['chef_client']['log_dir']     = "/var/adm/chef"
+  default['chef_client']['run_path']    = '/var/run/chef'
+  default['chef_client']['file_cache_path'] = '/var/spool/chef'
+  default['chef_client']['file_backup_path'] = '/var/lib/chef'
+  default['chef_client']['log_dir']     = '/var/adm/chef'
 when 'amazon', 'rhel', 'fedora', 'debian', 'suse', 'clearlinux'
   default['chef_client']['init_style']  = node['init_package']
-  default['chef_client']['run_path']    = "/var/run/chef"
-  default['chef_client']['file_cache_path'] = "/var/cache/chef"
-  default['chef_client']['file_backup_path'] = "/var/lib/chef"
+  default['chef_client']['run_path']    = '/var/run/chef'
+  default['chef_client']['file_cache_path'] = '/var/cache/chef'
+  default['chef_client']['file_backup_path'] = '/var/lib/chef'
   default['chef_client']['chkconfig']['start_order'] = 98
   default['chef_client']['chkconfig']['stop_order']  = 02
 when 'freebsd'
   default['chef_client']['init_style']  = 'bsd'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = "/var/chef/cache"
-  default['chef_client']['file_backup_path'] = "/var/chef/backup"
+  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  default['chef_client']['file_backup_path'] = '/var/chef/backup'
 # don't use bsd paths per COOK-1379
 when 'mac_os_x'
   default['chef_client']['init_style']  = 'launchd'
   default['chef_client']['log_dir']     = "/Library/Logs/#{node['chef_client']['dist'].capitalize}"
   # Launchd doesn't use pid files
-  default['chef_client']['run_path']    = "/var/run/chef"
+  default['chef_client']['run_path']    = '/var/run/chef'
   default['chef_client']['file_cache_path'] = "/Library/Caches/#{node['chef_client']['dist'].capitalize}"
   default['chef_client']['file_backup_path'] = "/Library/Caches/#{node['chef_client']['dist'].capitalize}/Backup"
   # Set to 'daemon' if you want chef-client to run
@@ -150,25 +150,25 @@ when 'mac_os_x'
   default['chef_client']['launchd_self-update'] = false
 when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
   default['chef_client']['init_style']  = 'smf'
-  default['chef_client']['run_path']    = "/var/run/chef"
-  default['chef_client']['file_cache_path'] = "/var/chef/cache"
-  default['chef_client']['file_backup_path'] = "/var/chef/backup"
+  default['chef_client']['run_path']    = '/var/run/chef'
+  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  default['chef_client']['file_backup_path'] = '/var/chef/backup'
   default['chef_client']['method_dir'] = '/lib/svc/method'
   default['chef_client']['bin_dir'] = '/usr/bin'
   default['chef_client']['locale'] = 'en_US.UTF-8'
   default['chef_client']['env_path'] = '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
 when 'smartos'
   default['chef_client']['init_style']  = 'smf'
-  default['chef_client']['run_path']    = "/var/run/chef"
-  default['chef_client']['file_cache_path'] = "/var/chef/cache"
-  default['chef_client']['file_backup_path'] = "/var/chef/backup"
+  default['chef_client']['run_path']    = '/var/run/chef'
+  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  default['chef_client']['file_backup_path'] = '/var/chef/backup'
   default['chef_client']['method_dir'] = '/opt/local/lib/svc/method'
   default['chef_client']['bin_dir'] = '/opt/local/bin'
   default['chef_client']['locale'] = 'en_US.UTF-8'
   default['chef_client']['env_path'] = '/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin'
 when 'windows'
   default['chef_client']['init_style']  = 'windows'
-  default['chef_client']['conf_dir']    = "C:/chef"
+  default['chef_client']['conf_dir']    = 'C:/chef'
   default['chef_client']['run_path']    = "#{node['chef_client']['conf_dir']}/run"
   default['chef_client']['file_cache_path'] = "#{node['chef_client']['conf_dir']}/cache"
   default['chef_client']['file_backup_path'] = "#{node['chef_client']['conf_dir']}/backup"
@@ -177,8 +177,8 @@ when 'windows'
 else
   default['chef_client']['init_style']  = 'none'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = "/var/chef/cache"
-  default['chef_client']['file_backup_path'] = "/var/chef/backup"
+  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  default['chef_client']['file_backup_path'] = '/var/chef/backup'
 end
 
 # Need to set this Option in client.rb
@@ -189,7 +189,7 @@ default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil
 default['chef_client']['log_rotation']['postrotate'] =  case node['chef_client']['init_style']
                                                         when 'systemd'
-                                                          node['chef_client']['systemd']['timer'] ? '' : "systemctl reload chef-client.service >/dev/null || :"
+                                                          node['chef_client']['systemd']['timer'] ? '' : 'systemctl reload chef-client.service >/dev/null || :'
                                                         else
-                                                          "/etc/init.d/chef-client reload >/dev/null || :"
+                                                          '/etc/init.d/chef-client reload >/dev/null || :'
                                                         end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,12 +39,12 @@ default['chef_client']['chef_license'] = nil
 default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
-default['chef_client']['conf_dir']    = "/etc/#{node['chef_client']['dist']}"
-default['chef_client']['bin']         = "/opt/#{node['chef_client']['dist']}/bin/#{node['chef_client']['dist']}-client"
+default['chef_client']['conf_dir']    = "/etc/chef"
+default['chef_client']['bin']         = "/opt/chef/bin/chef-client"
 
 # Set a sane default log directory location, overriden by specific
 # platforms below.
-default['chef_client']['log_dir']     = "/var/log/#{node['chef_client']['dist']}"
+default['chef_client']['log_dir']     = "/var/log/chef"
 
 # If log file is used, default permissions so everyone can read
 default['chef_client']['log_perm'] = '640'
@@ -80,7 +80,7 @@ default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for non-system users
 default['chef_client']['task']['start_time'] = nil
 default['chef_client']['task']['start_date'] = nil
-default['chef_client']['task']['name'] = "#{node['chef_client']['dist']}-client"
+default['chef_client']['task']['name'] = "chef-client"
 
 default['chef_client']['load_gems'] = {}
 
@@ -117,28 +117,28 @@ case node['platform_family']
 when 'aix'
   default['chef_client']['init_style']  = 'src'
   default['chef_client']['svc_name']    = node['chef_client']['dist']
-  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
-  default['chef_client']['file_cache_path'] = "/var/spool/#{node['chef_client']['dist']}"
-  default['chef_client']['file_backup_path'] = "/var/lib/#{node['chef_client']['dist']}"
-  default['chef_client']['log_dir']     = "/var/adm/#{node['chef_client']['dist']}"
+  default['chef_client']['run_path']    = "/var/run/chef"
+  default['chef_client']['file_cache_path'] = "/var/spool/chef"
+  default['chef_client']['file_backup_path'] = "/var/lib/chef"
+  default['chef_client']['log_dir']     = "/var/adm/chef"
 when 'amazon', 'rhel', 'fedora', 'debian', 'suse', 'clearlinux'
   default['chef_client']['init_style']  = node['init_package']
-  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
-  default['chef_client']['file_cache_path'] = "/var/cache/#{node['chef_client']['dist']}"
-  default['chef_client']['file_backup_path'] = "/var/lib/#{node['chef_client']['dist']}"
+  default['chef_client']['run_path']    = "/var/run/chef"
+  default['chef_client']['file_cache_path'] = "/var/cache/chef"
+  default['chef_client']['file_backup_path'] = "/var/lib/chef"
   default['chef_client']['chkconfig']['start_order'] = 98
   default['chef_client']['chkconfig']['stop_order']  = 02
 when 'freebsd'
   default['chef_client']['init_style']  = 'bsd'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
-  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
+  default['chef_client']['file_cache_path'] = "/var/chef/cache"
+  default['chef_client']['file_backup_path'] = "/var/chef/backup"
 # don't use bsd paths per COOK-1379
 when 'mac_os_x'
   default['chef_client']['init_style']  = 'launchd'
   default['chef_client']['log_dir']     = "/Library/Logs/#{node['chef_client']['dist'].capitalize}"
   # Launchd doesn't use pid files
-  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
+  default['chef_client']['run_path']    = "/var/run/chef"
   default['chef_client']['file_cache_path'] = "/Library/Caches/#{node['chef_client']['dist'].capitalize}"
   default['chef_client']['file_backup_path'] = "/Library/Caches/#{node['chef_client']['dist'].capitalize}/Backup"
   # Set to 'daemon' if you want chef-client to run
@@ -150,25 +150,25 @@ when 'mac_os_x'
   default['chef_client']['launchd_self-update'] = false
 when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
   default['chef_client']['init_style']  = 'smf'
-  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
-  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
-  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
+  default['chef_client']['run_path']    = "/var/run/chef"
+  default['chef_client']['file_cache_path'] = "/var/chef/cache"
+  default['chef_client']['file_backup_path'] = "/var/chef/backup"
   default['chef_client']['method_dir'] = '/lib/svc/method'
   default['chef_client']['bin_dir'] = '/usr/bin'
   default['chef_client']['locale'] = 'en_US.UTF-8'
   default['chef_client']['env_path'] = '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
 when 'smartos'
   default['chef_client']['init_style']  = 'smf'
-  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
-  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
-  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
+  default['chef_client']['run_path']    = "/var/run/chef"
+  default['chef_client']['file_cache_path'] = "/var/chef/cache"
+  default['chef_client']['file_backup_path'] = "/var/chef/backup"
   default['chef_client']['method_dir'] = '/opt/local/lib/svc/method'
   default['chef_client']['bin_dir'] = '/opt/local/bin'
   default['chef_client']['locale'] = 'en_US.UTF-8'
   default['chef_client']['env_path'] = '/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin'
 when 'windows'
   default['chef_client']['init_style']  = 'windows'
-  default['chef_client']['conf_dir']    = "C:/#{node['chef_client']['dist']}"
+  default['chef_client']['conf_dir']    = "C:/chef"
   default['chef_client']['run_path']    = "#{node['chef_client']['conf_dir']}/run"
   default['chef_client']['file_cache_path'] = "#{node['chef_client']['conf_dir']}/cache"
   default['chef_client']['file_backup_path'] = "#{node['chef_client']['conf_dir']}/backup"
@@ -177,8 +177,8 @@ when 'windows'
 else
   default['chef_client']['init_style']  = 'none'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
-  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
+  default['chef_client']['file_cache_path'] = "/var/chef/cache"
+  default['chef_client']['file_backup_path'] = "/var/chef/backup"
 end
 
 # Need to set this Option in client.rb
@@ -189,7 +189,7 @@ default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil
 default['chef_client']['log_rotation']['postrotate'] =  case node['chef_client']['init_style']
                                                         when 'systemd'
-                                                          node['chef_client']['systemd']['timer'] ? '' : "systemctl reload #{node['chef_client']['dist']}-client.service >/dev/null || :"
+                                                          node['chef_client']['systemd']['timer'] ? '' : "systemctl reload chef-client.service >/dev/null || :"
                                                         else
-                                                          "/etc/init.d/#{node['chef_client']['dist']}-client reload >/dev/null || :"
+                                                          "/etc/init.d/chef-client reload >/dev/null || :"
                                                         end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,18 +30,21 @@ default['chef_client']['config'] = {
   'verify_api_cert' => true,
 }
 
+# If you're using a community maintained fork of Chef, then set this to the appropriate name.
+default['chef_client']['dist'] = 'chef'
+
 # Accept the chef license when running the chef service
 default['chef_client']['chef_license'] = nil
 
 default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
-default['chef_client']['conf_dir']    = '/etc/chef'
-default['chef_client']['bin']         = '/opt/chef/bin/chef-client'
+default['chef_client']['conf_dir']    = "/etc/#{node['chef_client']['dist']}"
+default['chef_client']['bin']         = "/opt/#{node['chef_client']['dist']}/bin/#{node['chef_client']['dist']}-client"
 
 # Set a sane default log directory location, overriden by specific
 # platforms below.
-default['chef_client']['log_dir']     = '/var/log/chef'
+default['chef_client']['log_dir']     = "/var/log/#{node['chef_client']['dist']}"
 
 # If log file is used, default permissions so everyone can read
 default['chef_client']['log_perm'] = '640'
@@ -77,7 +80,7 @@ default['chef_client']['task']['user'] = 'SYSTEM'
 default['chef_client']['task']['password'] = nil # Password is only required for non-system users
 default['chef_client']['task']['start_time'] = nil
 default['chef_client']['task']['start_date'] = nil
-default['chef_client']['task']['name'] = 'chef-client'
+default['chef_client']['task']['name'] = "#{node['chef_client']['dist']}-client"
 
 default['chef_client']['load_gems'] = {}
 
@@ -113,31 +116,31 @@ default['chef_client']['logrotate']['frequency'] = 'weekly'
 case node['platform_family']
 when 'aix'
   default['chef_client']['init_style']  = 'src'
-  default['chef_client']['svc_name']    = 'chef'
-  default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/spool/chef'
-  default['chef_client']['file_backup_path'] = '/var/lib/chef'
-  default['chef_client']['log_dir']     = '/var/adm/chef'
+  default['chef_client']['svc_name']    = node['chef_client']['dist']
+  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
+  default['chef_client']['file_cache_path'] = "/var/spool/#{node['chef_client']['dist']}"
+  default['chef_client']['file_backup_path'] = "/var/lib/#{node['chef_client']['dist']}"
+  default['chef_client']['log_dir']     = "/var/adm/#{node['chef_client']['dist']}"
 when 'amazon', 'rhel', 'fedora', 'debian', 'suse', 'clearlinux'
   default['chef_client']['init_style']  = node['init_package']
-  default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/cache/chef'
-  default['chef_client']['file_backup_path'] = '/var/lib/chef'
+  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
+  default['chef_client']['file_cache_path'] = "/var/cache/#{node['chef_client']['dist']}"
+  default['chef_client']['file_backup_path'] = "/var/lib/#{node['chef_client']['dist']}"
   default['chef_client']['chkconfig']['start_order'] = 98
   default['chef_client']['chkconfig']['stop_order']  = 02
 when 'freebsd'
   default['chef_client']['init_style']  = 'bsd'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
-  default['chef_client']['file_backup_path'] = '/var/chef/backup'
+  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
+  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
 # don't use bsd paths per COOK-1379
 when 'mac_os_x'
   default['chef_client']['init_style']  = 'launchd'
-  default['chef_client']['log_dir']     = '/Library/Logs/Chef'
+  default['chef_client']['log_dir']     = "/Library/Logs/#{node['chef_client']['dist'].capitalize}"
   # Launchd doesn't use pid files
-  default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/Library/Caches/Chef'
-  default['chef_client']['file_backup_path'] = '/Library/Caches/Chef/Backup'
+  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
+  default['chef_client']['file_cache_path'] = "/Library/Caches/#{node['chef_client']['dist'].capitalize}"
+  default['chef_client']['file_backup_path'] = "/Library/Caches/#{node['chef_client']['dist'].capitalize}/Backup"
   # Set to 'daemon' if you want chef-client to run
   # continuously with the -d and -s options, or leave
   # as 'interval' if you want chef-client to be run
@@ -147,25 +150,25 @@ when 'mac_os_x'
   default['chef_client']['launchd_self-update'] = false
 when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
   default['chef_client']['init_style']  = 'smf'
-  default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
-  default['chef_client']['file_backup_path'] = '/var/chef/backup'
+  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
+  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
+  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
   default['chef_client']['method_dir'] = '/lib/svc/method'
   default['chef_client']['bin_dir'] = '/usr/bin'
   default['chef_client']['locale'] = 'en_US.UTF-8'
   default['chef_client']['env_path'] = '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
 when 'smartos'
   default['chef_client']['init_style']  = 'smf'
-  default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
-  default['chef_client']['file_backup_path'] = '/var/chef/backup'
+  default['chef_client']['run_path']    = "/var/run/#{node['chef_client']['dist']}"
+  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
+  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
   default['chef_client']['method_dir'] = '/opt/local/lib/svc/method'
   default['chef_client']['bin_dir'] = '/opt/local/bin'
   default['chef_client']['locale'] = 'en_US.UTF-8'
   default['chef_client']['env_path'] = '/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin'
 when 'windows'
   default['chef_client']['init_style']  = 'windows'
-  default['chef_client']['conf_dir']    = 'C:/chef'
+  default['chef_client']['conf_dir']    = "C:/#{node['chef_client']['dist']}"
   default['chef_client']['run_path']    = "#{node['chef_client']['conf_dir']}/run"
   default['chef_client']['file_cache_path'] = "#{node['chef_client']['conf_dir']}/cache"
   default['chef_client']['file_backup_path'] = "#{node['chef_client']['conf_dir']}/backup"
@@ -174,8 +177,8 @@ when 'windows'
 else
   default['chef_client']['init_style']  = 'none'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
-  default['chef_client']['file_backup_path'] = '/var/chef/backup'
+  default['chef_client']['file_cache_path'] = "/var/#{node['chef_client']['dist']}/cache"
+  default['chef_client']['file_backup_path'] = "/var/#{node['chef_client']['dist']}/backup"
 end
 
 # Need to set this Option in client.rb
@@ -186,7 +189,7 @@ default['chef_client']['log_rotation']['options'] = ['compress']
 default['chef_client']['log_rotation']['prerotate'] = nil
 default['chef_client']['log_rotation']['postrotate'] =  case node['chef_client']['init_style']
                                                         when 'systemd'
-                                                          node['chef_client']['systemd']['timer'] ? '' : 'systemctl reload chef-client.service >/dev/null || :'
+                                                          node['chef_client']['systemd']['timer'] ? '' : "systemctl reload #{node['chef_client']['dist']}-client.service >/dev/null || :"
                                                         else
-                                                          '/etc/init.d/chef-client reload >/dev/null || :'
+                                                          "/etc/init.d/#{node['chef_client']['dist']}-client reload >/dev/null || :"
                                                         end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,8 +30,7 @@ default['chef_client']['config'] = {
   'verify_api_cert' => true,
 }
 
-# If you're using a community maintained fork of Chef, then set this to the appropriate name.
-default['chef_client']['dist'] = 'chef'
+default['chef_client']['dist'] = Gem::Requirement.new('>= 15.0.225').satisfied_by?(Gem::Version.new(Chef::VERSION)) ? Chef::Dist::EXEC : 'chef'
 
 # Accept the chef license when running the chef service
 default['chef_client']['chef_license'] = nil

--- a/recipes/bsd_service.rb
+++ b/recipes/bsd_service.rb
@@ -8,7 +8,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-Chef::Log.debug("Using chef-client binary at #{client_bin}")
+Chef::Log.debug("Using #{node['chef_client']['dist']}-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 
@@ -20,7 +20,7 @@ if platform_family?('freebsd')
     action :create
   end
 
-  template '/usr/local/etc/rc.d/chef-client' do
+  template "/usr/local/etc/rc.d/#{node['chef_client']['dist']}-client" do
     source 'default/freebsd/chef-client.erb'
     owner 'root'
     group 'wheel'
@@ -29,21 +29,21 @@ if platform_family?('freebsd')
   end
 
   # Remove wrong rc.d script created by an older version of cookbook
-  file '/etc/rc.d/chef-client' do
+  file "/etc/rc.d/#{node['chef_client']['dist']}-client" do
     action :delete
   end
 
-  template '/etc/rc.conf.d/chef' do
+  template "/etc/rc.conf.d/#{node['chef_client']['dist']}" do
     source 'default/freebsd/chef.erb'
     mode '0644'
-    notifies :start, 'service[chef-client]', :delayed
+    notifies :start, "service[#{node['chef_client']['dist']}-client]", :delayed
   end
 
-  service 'chef-client' do
+  service "#{node['chef_client']['dist']}-client" do
     supports status: true, restart: true
     action [:start]
   end
 
 else
-  log "You specified service style 'bsd'. You will need to set up your rc.local file. Hint: chef-client -i #{node['chef_client']['client_interval']} -s #{node['chef_client']['client_splay']}"
+  log "You specified service style 'bsd'. You will need to set up your rc.local file. Hint: #{node['chef_client']['dist']}-client -i #{node['chef_client']['client_interval']} -s #{node['chef_client']['client_splay']}"
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -32,7 +32,7 @@ if node['chef_client']['log_file'].is_a?(String)
   node.default['chef_client']['config']['log_location'] = log_path
 
   if node['os'] == 'linux'
-    logrotate_app 'chef-client' do
+    logrotate_app "#{node['chef_client']['dist']}-client" do
       path [log_path]
       rotate node['chef_client']['logrotate']['rotate']
       frequency node['chef_client']['logrotate']['frequency']

--- a/recipes/init_service.rb
+++ b/recipes/init_service.rb
@@ -11,7 +11,7 @@ Chef::Log.debug("Using chef-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 
-template '/etc/init.d/chef-client' do
+template "/etc/init.d/#{node['chef_client']['dist']}-client" do
   source 'redhat/init.d/chef-client.erb'
   mode '0755'
   variables(client_bin: client_bin,
@@ -20,13 +20,13 @@ template '/etc/init.d/chef-client' do
   notifies :restart, 'service[chef-client]', :delayed
 end
 
-template '/etc/sysconfig/chef-client' do
+template "/etc/sysconfig/#{node['chef_client']['dist']}-client" do
   source 'redhat/sysconfig/chef-client.erb'
   mode '0644'
-  notifies :restart, 'service[chef-client]', :delayed
+  notifies :restart, "service[#{node['chef_client']['dist']}-client]", :delayed
 end
 
-service 'chef-client' do
+service "#{node['chef_client']['dist']}-client" do
   supports status: true, restart: true
   action [:enable, :start]
 end

--- a/recipes/launchd_service.rb
+++ b/recipes/launchd_service.rb
@@ -7,12 +7,12 @@ require 'chef/version_constraint'
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-Chef::Log.debug("Using chef-client binary at #{client_bin}")
+Chef::Log.debug("Using #{node['chef_client']['dist']}-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 
 create_chef_directories
 
-template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
+template "/Library/LaunchDaemons/com.#{node['chef_client']['dist']}.#{node['chef_client']['dist']}-client.plist" do
   source 'com.chef.chef-client.plist.erb'
   mode '0644'
   variables(
@@ -25,15 +25,15 @@ template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
     splay: node['chef_client']['splay'],
     working_dir: node['chef_client']['launchd_working_dir']
   )
-  notifies :restart, 'macosx_service[com.chef.chef-client]' if node['chef_client']['launchd_self-update']
+  notifies :restart, "macosx_service[com.#{node['chef_client']['dist']}.#{node['chef_client']['dist']}-client]" if node['chef_client']['launchd_self-update']
 end
 
-macosx_service 'com.chef.chef-client' do
+macosx_service "com.#{node['chef_client']['dist']}.#{node['chef_client']['dist']}-client" do
   action :nothing
 end
 
-macosx_service 'chef-client' do
-  service_name 'com.chef.chef-client'
-  plist '/Library/LaunchDaemons/com.chef.chef-client.plist'
+macosx_service "#{node['chef_client']['dist']}-client" do
+  service_name "com.#{node['chef_client']['dist']}.#{node['chef_client']['dist']}-client"
+  plist "/Library/LaunchDaemons/com.#{node['chef_client']['dist']}.#{node['chef_client']['dist']}-client.plist"
   action :start
 end

--- a/recipes/src_service.rb
+++ b/recipes/src_service.rb
@@ -26,7 +26,7 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-Chef::Log.debug("Using chef-client binary at #{client_bin}")
+Chef::Log.debug("Using #{node['chef_client']['dist']}-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 create_chef_directories
 

--- a/recipes/task.rb
+++ b/recipes/task.rb
@@ -25,10 +25,11 @@ end
 
 # libraries/helpers.rb method to DRY directory creation resources
 client_bin = find_chef_client
-Chef::Log.info("Using chef-client binary at #{client_bin}")
+Chef::Log.info("Using #{node['chef_client']['dist']}-client binary at #{client_bin}")
 node.default['chef_client']['bin'] = client_bin
 
 chef_client_scheduled_task 'Chef Client' do
+  task_name "#{node['chef_client']['dist']}-client"
   user node['chef_client']['task']['user']
   password node['chef_client']['task']['password']
   frequency node['chef_client']['task']['frequency']
@@ -47,5 +48,5 @@ windows_service 'chef-client' do
   startup_type :disabled
   action [:configure_startup, :stop]
   ignore_failure true
-  only_if { ::Win32::Service.exists?('chef-client') }
+  only_if { ::Win32::Service.exists?("#{node['chef_client']['dist']}-client") }
 end


### PR DESCRIPTION
This makes it a bit easier to use community forks with Chef.

### Description
Community forks may use a different `dist` name, but have the same basic setup. To that end, this adds a `dist` attribute that lets people use different community distributions of Chef with this cookbook. The config namespace is unchanged, as interpolation there may prove to be a bit unreadable. 

### Issues Resolved
As is, if you override these variables (say you're using `cinc`):
```
  node.override['ohai']['plugin_path'] = '/etc/cinc/ohai/plugins'
  node.override['chef_client']['conf_dir'] = '/etc/cinc'
  node.override['chef_client']['bin'] = '/opt/cinc/bin/cinc-client'
  node.override['chef_client']['log_dir'] = '/var/log/cinc'
  node.override['chef_client']['run_path'] = '/var/run/cinc'
  node.override['chef_client']['file_cache_path'] = '/var/cache/cinc'
  node.override['chef_client']['file_backup_path'] = '/var/lib/cinc'
```
you can deploy using this cookbook - however the run mechanisms (ie. systemd on ubuntu) will still be put down on disk as `chef-client.service` which may be confusing for folks.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>