### PR TITLE
Prevent usage of custom resources by chef 16+

### DIFF
--- a/resources/cron.rb
+++ b/resources/cron.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 16.0' if respond_to?(:chef_version_for_provides)
+
 provides :chef_client_cron
 resource_name :chef_client_cron
 

--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 16.0' if respond_to?(:chef_version_for_provides)
+
 provides :chef_client_scheduled_task
 resource_name :chef_client_scheduled_task
 

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+chef_version_for_provides '< 16.0' if respond_to?(:chef_version_for_provides)
+
 provides :chef_client_systemd_timer
 resource_name :chef_client_systemd_timer
 


### PR DESCRIPTION
Prevent this cookbook's custom resources from loading on chef 16+ since the resources became native in that version.

### Description
Adds a `chef_version_for_provides` guard requiring chef version to be < 16.0 for the chef-client scheduling resources to be loaded.

### Issues Resolved
Basically this: https://github.com/chef/chef/issues/10105

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>