### PR TITLE
scheduled_task.rb: fix client_cmd return value

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -106,6 +106,8 @@ action_class do
     # Add custom options
     cmd << " #{new_resource.daemon_options.join(' ')}" if new_resource.daemon_options.any?
     cmd << ' --chef-license accept' if new_resource.accept_chef_license && Gem::Requirement.new('>= 14.12.9').satisfied_by?(Gem::Version.new(Chef::VERSION))
+
+    cmd
   end
 
   #


### PR DESCRIPTION
### Description
The current implementation of client_cmd has no return value, so the command that gets put into the windows scheduled task is empty. This adds a return value, which means it wont be empty anymore.

### Issues Resolved
* Fixes #681

### Check List
- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>