### PR TITLE
Fix quoting behavior in scheduled tasks

### DIFF
--- a/resources/scheduled_task.rb
+++ b/resources/scheduled_task.rb
@@ -86,11 +86,7 @@ action_class do
     # Fetch path of cmd.exe through environment variable comspec
     cmd_path = ENV['COMSPEC']
 
-    if Gem::Requirement.new('< 13.7.0').satisfied_by?(Gem::Version.new(Chef::VERSION)) || Gem::Requirement.new('>= 14.4.0').satisfied_by?(Gem::Version.new(Chef::VERSION))
-      "#{cmd_path} /c \"#{client_cmd}\""
-    else
-      "#{cmd_path} /c \'#{client_cmd}\'"
-    end
+    "#{cmd_path} /c \"#{client_cmd}\""
   end
 
   #
@@ -106,7 +102,6 @@ action_class do
     # Add custom options
     cmd << " #{new_resource.daemon_options.join(' ')}" if new_resource.daemon_options.any?
     cmd << ' --chef-license accept' if new_resource.accept_chef_license && Gem::Requirement.new('>= 14.12.9').satisfied_by?(Gem::Version.new(Chef::VERSION))
-
     cmd
   end
 


### PR DESCRIPTION
### Description
Uses double quotes with cmd.exe command string, because single quotes do not work.

### Issues Resolved
From https://github.com/chef/chef/issues/10175

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>