### PR TITLE
Disable file_cache_path attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This file is used to list changes made in each version of the chef-client cookbo
 - The default binary path on Linux, macOS and other *nix operating systems has been changed from `/usr/bin/chef-client` to `/opt/chef/bin/chef-client`
 - The upstart service recipe has been removed as Ubuntu 14.04 is now EOL
 - Support for non-RHEL platforms in the init service recipe has been removed as only RHEL 6 / Amazon 201x should need sys-v init support at this point
-- The `node['chef_client']['cache_path']` attribute has been renamed to `node['chef_client']['file_cache_path']` and will properly be set in the client.rb if changed now.
+- The `node['chef_client']['cache_path']` attribute has been renamed to `node['chef_client']['file_cache_path']` and will properly be set in the client.rb if changed now. However, this attribute is unset by default as it causes issues on first client runs. Enable it at your own risk.
 - The `node['chef_client']['backup_path']` attribute has been renamed to `node['chef_client']['file_backup_path']` and will properly be set in the client.rb if changed now.
 - The `chef_client_scheduled_task` resource no longer uses the `node['chef_client']['log_file']` to set the log file name and intead had a new `log_file_name` property that defaults to `chef-client.log` matching the attributes default value.
 - A new `client.rb` configuration option `file_staging_uses_destdir` is set via `node['chef_client']['file_staging_uses_destdir']`, which defaults to true.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 
 - `node['chef_client']['init_style']` - Sets up the client service based on the style of init system to use. Default is based on platform and falls back to `'none'`. See [service recipes](#service-recipes).
 - `node['chef_client']['run_path']` - Directory location where chef-client should write the PID file. Default based on platform, falls back to "/var/run".
-- `node['chef_client']['cache_path']` - Directory location for `Chef::Config[:file_cache_path]` where chef-client will cache various files. Default is based on platform, falls back to "/var/chef/cache".
-- `node['chef_client']['backup_path']` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
+- `node['chef_client']['file_cache_path']` - Directory location for `Chef::Config[:file_cache_path]` where chef-client will cache various files. Default is unset as it causes problems on first chef runs. The default location is typically "/var/cache/cache" but could be different based on the platform. Use this attribute at your own risk.
+- `node['chef_client']['file_backup_path']` - Directory location for `Chef::Config[:file_backup_path]` where chef-client will backup templates and cookbook files. Default is based on platform, falls back to "/var/chef/backup".
 - `node['chef_client']['file_staging_uses_destdir']` - How file staging (via temporary files) is done. When true, temporary files are created in the directory in which files will reside. When false, temporary files are created under ENV['TMP']. Default value: true.
 This cookbook makes use of attribute-driven configuration with this attribute. See [USAGE](#usage) for examples.
 - `node['chef_client']['launchd_mode']` - (only for macOS) If set to `'daemon'`, runs chef-client with `-d` and `-s` options; defaults to `'interval'`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -115,20 +115,20 @@ when 'aix'
   default['chef_client']['init_style']  = 'src'
   default['chef_client']['svc_name']    = 'chef'
   default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/spool/chef'
+  # default['chef_client']['file_cache_path'] = '/var/spool/chef'
   default['chef_client']['file_backup_path'] = '/var/lib/chef'
   default['chef_client']['log_dir']     = '/var/adm/chef'
 when 'amazon', 'rhel', 'fedora', 'debian', 'suse', 'clearlinux'
   default['chef_client']['init_style']  = node['init_package']
   default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/cache/chef'
+  # default['chef_client']['file_cache_path'] = '/var/cache/chef'
   default['chef_client']['file_backup_path'] = '/var/lib/chef'
   default['chef_client']['chkconfig']['start_order'] = 98
   default['chef_client']['chkconfig']['stop_order']  = 02
 when 'freebsd'
   default['chef_client']['init_style']  = 'bsd'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
 # don't use bsd paths per COOK-1379
 when 'mac_os_x'
@@ -136,7 +136,7 @@ when 'mac_os_x'
   default['chef_client']['log_dir']     = '/Library/Logs/Chef'
   # Launchd doesn't use pid files
   default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/Library/Caches/Chef'
+  # default['chef_client']['file_cache_path'] = '/Library/Caches/Chef'
   default['chef_client']['file_backup_path'] = '/Library/Caches/Chef/Backup'
   # Set to 'daemon' if you want chef-client to run
   # continuously with the -d and -s options, or leave
@@ -148,7 +148,7 @@ when 'mac_os_x'
 when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
   default['chef_client']['init_style']  = 'smf'
   default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
   default['chef_client']['method_dir'] = '/lib/svc/method'
   default['chef_client']['bin_dir'] = '/usr/bin'
@@ -157,7 +157,7 @@ when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
 when 'smartos'
   default['chef_client']['init_style']  = 'smf'
   default['chef_client']['run_path']    = '/var/run/chef'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
   default['chef_client']['method_dir'] = '/opt/local/lib/svc/method'
   default['chef_client']['bin_dir'] = '/opt/local/bin'
@@ -167,14 +167,14 @@ when 'windows'
   default['chef_client']['init_style']  = 'windows'
   default['chef_client']['conf_dir']    = 'C:/chef'
   default['chef_client']['run_path']    = "#{node['chef_client']['conf_dir']}/run"
-  default['chef_client']['file_cache_path'] = "#{node['chef_client']['conf_dir']}/cache"
+  # default['chef_client']['file_cache_path'] = "#{node['chef_client']['conf_dir']}/cache"
   default['chef_client']['file_backup_path'] = "#{node['chef_client']['conf_dir']}/backup"
   default['chef_client']['log_dir']     = "#{node['chef_client']['conf_dir']}/log"
   default['chef_client']['bin']         = 'C:/opscode/chef/bin/chef-client'
 else
   default['chef_client']['init_style']  = 'none'
   default['chef_client']['run_path']    = '/var/run'
-  default['chef_client']['file_cache_path'] = '/var/chef/cache'
+  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -115,20 +115,17 @@ when 'aix'
   default['chef_client']['init_style']  = 'src'
   default['chef_client']['svc_name']    = 'chef'
   default['chef_client']['run_path']    = '/var/run/chef'
-  # default['chef_client']['file_cache_path'] = '/var/spool/chef'
   default['chef_client']['file_backup_path'] = '/var/lib/chef'
   default['chef_client']['log_dir']     = '/var/adm/chef'
 when 'amazon', 'rhel', 'fedora', 'debian', 'suse', 'clearlinux'
   default['chef_client']['init_style']  = node['init_package']
   default['chef_client']['run_path']    = '/var/run/chef'
-  # default['chef_client']['file_cache_path'] = '/var/cache/chef'
   default['chef_client']['file_backup_path'] = '/var/lib/chef'
   default['chef_client']['chkconfig']['start_order'] = 98
   default['chef_client']['chkconfig']['stop_order']  = 02
 when 'freebsd'
   default['chef_client']['init_style']  = 'bsd'
   default['chef_client']['run_path']    = '/var/run'
-  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
 # don't use bsd paths per COOK-1379
 when 'mac_os_x'
@@ -136,7 +133,6 @@ when 'mac_os_x'
   default['chef_client']['log_dir']     = '/Library/Logs/Chef'
   # Launchd doesn't use pid files
   default['chef_client']['run_path']    = '/var/run/chef'
-  # default['chef_client']['file_cache_path'] = '/Library/Caches/Chef'
   default['chef_client']['file_backup_path'] = '/Library/Caches/Chef/Backup'
   # Set to 'daemon' if you want chef-client to run
   # continuously with the -d and -s options, or leave
@@ -148,7 +144,6 @@ when 'mac_os_x'
 when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
   default['chef_client']['init_style']  = 'smf'
   default['chef_client']['run_path']    = '/var/run/chef'
-  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
   default['chef_client']['method_dir'] = '/lib/svc/method'
   default['chef_client']['bin_dir'] = '/usr/bin'
@@ -157,7 +152,6 @@ when 'openindiana', 'opensolaris', 'nexentacore', 'solaris2', 'omnios'
 when 'smartos'
   default['chef_client']['init_style']  = 'smf'
   default['chef_client']['run_path']    = '/var/run/chef'
-  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
   default['chef_client']['method_dir'] = '/opt/local/lib/svc/method'
   default['chef_client']['bin_dir'] = '/opt/local/bin'
@@ -167,14 +161,12 @@ when 'windows'
   default['chef_client']['init_style']  = 'windows'
   default['chef_client']['conf_dir']    = 'C:/chef'
   default['chef_client']['run_path']    = "#{node['chef_client']['conf_dir']}/run"
-  # default['chef_client']['file_cache_path'] = "#{node['chef_client']['conf_dir']}/cache"
   default['chef_client']['file_backup_path'] = "#{node['chef_client']['conf_dir']}/backup"
   default['chef_client']['log_dir']     = "#{node['chef_client']['conf_dir']}/log"
   default['chef_client']['bin']         = 'C:/opscode/chef/bin/chef-client'
 else
   default['chef_client']['init_style']  = 'none'
   default['chef_client']['run_path']    = '/var/run'
-  # default['chef_client']['file_cache_path'] = '/var/chef/cache'
   default['chef_client']['file_backup_path'] = '/var/chef/backup'
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -50,6 +50,7 @@ module Opscode
         # root_owner is not in scope in the block below.
         d_owner = root_owner
         %w(run_path file_cache_path file_backup_path log_dir conf_dir).each do |dir|
+          next if node['chef_client'][dir].nil?
           # Do not redefine the resource if it exist
           find_resource(:directory, node['chef_client'][dir]) do
             recursive true

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -22,7 +22,7 @@ describe 'chef-client::config' do
 
   [
     '/var/run/chef',
-    '/var/cache/chef',
+    # '/var/cache/chef',
     '/var/lib/chef',
     '/var/log/chef',
     '/etc/chef',

--- a/spec/unit/cron_spec.rb
+++ b/spec/unit/cron_spec.rb
@@ -23,6 +23,7 @@ describe 'chef-client::cron' do
       ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04') do |node|
         node.normal['chef_client']['cron']['environment_variables'] = 'FOO=BAR'
         node.normal['chef_client']['cron']['append_log'] = true
+        node.normal['chef_client']['cron']['use_cron_d'] = false
       end.converge(described_recipe)
     end
 
@@ -41,30 +42,35 @@ describe 'chef-client::cron' do
     cached(:redhat_chef_run) do
       ChefSpec::ServerRunner.new(platform: 'redhat', version: '7') do |node|
         node.normal['chef_client']['cron']['priority'] = 19
+        node.normal['chef_client']['cron']['use_cron_d'] = false
       end.converge(described_recipe)
     end
 
     cached(:invalid_priority_chef_run) do
       ChefSpec::ServerRunner.new(platform: 'redhat', version: '7') do |node|
         node.normal['chef_client']['cron']['priority'] = 42
+        node.normal['chef_client']['cron']['use_cron_d'] = false
       end.converge(described_recipe)
     end
 
     cached(:string_but_valid_chef_run) do
       ChefSpec::ServerRunner.new(platform: 'redhat', version: '7') do |node|
         node.normal['chef_client']['cron']['priority'] = '-5'
+        node.normal['chef_client']['cron']['use_cron_d'] = false
       end.converge(described_recipe)
     end
 
     cached(:string_but_invalid_chef_run) do
       ChefSpec::ServerRunner.new(platform: 'redhat', version: '7') do |node|
         node.normal['chef_client']['cron']['priority'] = '123'
+        node.normal['chef_client']['cron']['use_cron_d'] = false
       end.converge(described_recipe)
     end
 
     cached(:gobbledeegook_chef_run) do
       ChefSpec::ServerRunner.new(platform: 'redhat', version: '7') do |node|
         node.normal['chef_client']['cron']['priority'] = 'hibbitydibbity-123'
+        node.normal['chef_client']['cron']['use_cron_d'] = false
       end.converge(described_recipe)
     end
 

--- a/spec/unit/cron_spec.rb
+++ b/spec/unit/cron_spec.rb
@@ -5,8 +5,8 @@ describe 'chef-client::cron' do
 
   [
     '/var/run/chef',
-    '/var/cache/chef',
-    '/var/cache/chef',
+    # '/var/cache/chef',
+    # '/var/cache/chef',
     '/var/log/chef',
     '/etc/chef',
   ].each do |dir|


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

This works around an issue where the converge fails on the first run with the
following error in chef-zero:

```
Object not found: chefzero://localhost:1/org
```

A second coverge seems to always pass however.

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>