### PR TITLE
Fix systemd_timer_resource :remove action failures

### DIFF
--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -56,11 +56,11 @@ end
 
 action :remove do
   systemd_unit "#{new_resource.job_name}.service" do
-    action :remove
+    action :delete
   end
 
   systemd_unit "#{new_resource.job_name}.timer" do
-    action :remove
+    action :delete
   end
 end
 

--- a/test/cookbooks/test/recipes/systemd_timer_resource.rb
+++ b/test/cookbooks/test/recipes/systemd_timer_resource.rb
@@ -3,3 +3,7 @@ chef_client_systemd_timer 'schedule chef-client to run as cron job' do
   daemon_options ['--run-lock-timeout 0']
   environment 'FOO' => '1', 'BAR' => '2'
 end
+
+chef_client_systemd_timer 'a timer that does not exist' do
+  action :remove
+end


### PR DESCRIPTION
Get the underlying action right

Signed-off-by: Tim Smith <tsmith@chef.io>