### PR TITLE
Add the initial chef_client_trusted_certificate resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ env:
   - CHEF_VERSION=13 INSTANCE=cron-ubuntu-1804
   - CHEF_VERSION=13 INSTANCE=cron-centos-6
   - CHEF_VERSION=13 INSTANCE=cron-centos-7
-  - CHEF_VERSION=13 INSTANCE=cron-opensuse-leap-15
   - CHEF_VERSION=13 INSTANCE=delete-validation-ubuntu-1804
   - CHEF_VERSION=13 INSTANCE=service-systemd-amazonlinux-2
   - CHEF_VERSION=13 INSTANCE=service-systemd-centos-7

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The chef_client_scheduled_task resource setups up Chef Infra Client to run as a 
 
 ### chef_client_cron
 
-The chef_client cron resource setups up Chef Infra Client to run as a cron job using a cron.d configuration file. You can use this resource directly in any of your own recipes.
+The chef_client_cron resource sets up Chef Infra Client to run as a cron job using a cron.d configuration file on Linux hosts or a job in /etc/crontab for other Unix operating systems. You can use this resource directly in any of your own recipes.
 
 ### Actions
 
@@ -90,6 +90,50 @@ The chef_client cron resource setups up Chef Infra Client to run as a cron job u
 - `append_log_file` - Whether to append to the log. Default: `true` chef-client output.
 - `chef_binary_path` - The path to the chef-client binary. default: '/opt/chef/bin/chef-client'
 - `daemon_options` - An optional array of extra command line options to pass to the chef-client
+
+### chef_client_trusted_certificate
+
+The chef_client_trusted_certificate allows you to add a certificate to Chef Infra Client's set of trusted certificates. This is helpful when adding internal certificates for systems that the Chef Infra Client will later need to communicate with using SSL. You can use this resource directly in any of your own recipes.
+
+### Actions
+
+- `:add`
+- `:remove`
+
+### Properties
+
+- `cert_name` - The name on disk for the cert file. If not specified the resource name will be used (and .pem appended if necessary)
+- `certificate` - The text content of the certificate file
+
+### Examples
+
+```ruby
+chef_client_trusted_certificate 'self-signed.badssl.com' do
+  certificate <<~CERT
+  -----BEGIN CERTIFICATE-----
+  MIIDeTCCAmGgAwIBAgIJAPziuikCTox4MA0GCSqGSIb3DQEBCwUAMGIxCzAJBgNV
+  BAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNp
+  c2NvMQ8wDQYDVQQKDAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTAeFw0x
+  OTEwMDkyMzQxNTJaFw0yMTEwMDgyMzQxNTJaMGIxCzAJBgNVBAYTAlVTMRMwEQYD
+  VQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ8wDQYDVQQK
+  DAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEB
+  BQADggEPADCCAQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2
+  PmzAS2BMTOqytMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMW
+  hyefdOsKnRFSJiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3A
+  xPxTuW1CrbV8/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqve
+  ww9HdFxBIuGa+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SY
+  QCeFxxC7c3DvaRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaMyMDAwCQYDVR0T
+  BAIwADAjBgNVHREEHDAaggwqLmJhZHNzbC5jb22CCmJhZHNzbC5jb20wDQYJKoZI
+  hvcNAQELBQADggEBAGlwCdbPxflZfYOaukZGCaxYK6gpincX4Lla4Ui2WdeQxE95
+  w7fChXvP3YkE3UYUE7mupZ0eg4ZILr/A0e7JQDsgIu/SRTUE0domCKgPZ8v99k3A
+  vka4LpLK51jHJJK7EFgo3ca2nldd97GM0MU41xHFk8qaK1tWJkfrrfcGwDJ4GQPI
+  iLlm6i0yHq1Qg1RypAXJy5dTlRXlCLd8ufWhhiwW0W75Va5AEnJuqpQrKwl3KQVe
+  wGj67WWRgLfSr+4QG1mNvCZb2CkjZWmxkGPuoP40/y7Yu5OFqxP5tAjj4YixCYTW
+  EVA0pmzIzgBg+JIe3PdRy27T0asgQW/F4TY61Yk=
+  -----END CERTIFICATE-----
+  CERT
+end
+```
 
 ## Attributes
 
@@ -138,8 +182,7 @@ The following attributes are set on a per-platform basis, see the `attributes/de
 This cookbook makes use of attribute-driven configuration with this attribute. See [USAGE](#usage) for examples.
 - `node['chef_client']['launchd_mode']` - (only for macOS) If set to `'daemon'`, runs chef-client with `-d` and `-s` options; defaults to `'interval'`.
 - `node['chef_client']['launchd_working_dir']` - (only for macOS) Sets the working directory for the launchd user (generally `root`); defaults to `/var/root`.
-- `node['chef_client']['launchd_self-update']` - (only for macOS) Determines whether chef-client should attempt to `:restart` itself when changes are made to the launchd plist during converge. Note that the [current implementation](https://github.com/chef/chef/blob/129a6f3982218e5eadcd33b272ba738b317bbcae/lib/chef/provider/service/macosx.rb#L128) of 
-`macosx_service` `:restart` unloads the daemon, which stops the current chef-client run and requires an external process to resume the service. Defaults to `false`.
+- `node['chef_client']['launchd_self-update']` - (only for macOS) Determines whether chef-client should attempt to `:restart` itself when changes are made to the launchd plist during converge. Note that the [current implementation](https://github.com/chef/chef/blob/129a6f3982218e5eadcd33b272ba738b317bbcae/lib/chef/provider/service/macosx.rb#L128) of `macosx_service` `:restart` unloads the daemon, which stops the current chef-client run and requires an external process to resume the service. Defaults to `false`.
 - When `chef_client['log_file']` is set and running on a [logrotate](https://supermarket.chef.io/cookbooks/logrotate) supported platform (debian, rhel, fedora family), use the following attributes to tune log rotation.
   - `node['chef_client']['logrotate']['rotate']` - Number of rotated logs to keep on disk, default 12.
   - `node['chef_client']['logrotate']['frequency']` - How often to rotate chef client logs, default weekly.

--- a/README.md
+++ b/README.md
@@ -467,10 +467,6 @@ This cookbook does not handle updating the chef-client, as that's out of the coo
 
 - [chef_client_updater](https://github.com/chef-cookbooks/chef_client_updater) - Cookbook for keeping your install up-to-date
 
-## Maintainers
-
-This cookbook is maintained by Chef's Community Cookbook Engineering team. Our goal is to improve cookbook quality and to aid the community in contributing to cookbooks. To learn more about our team, process, and design goals see our [team documentation](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/COOKBOOK_TEAM.MD). To learn more about contributing to cookbooks like this see our [contributing documentation](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD), or if you have general questions about this cookbook come chat with us in #cookbok-engineering on the [Chef Community Slack](http://community-slack.chef.io/)
-
 ## License
 
 **Copyright:** 2010-2020, Chef Software, Inc.

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,3 +1,4 @@
+---
 driver:
   name: dokken
   privileged: true # because Docker and SystemD

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,3 +1,4 @@
+---
 driver:
   name: vagrant
 

--- a/resources/trusted_certificate.rb
+++ b/resources/trusted_certificate.rb
@@ -44,7 +44,6 @@ end
 action :remove do
   file cert_path do
     action :delete
-    mode '0640'
   end
 end
 

--- a/resources/trusted_certificate.rb
+++ b/resources/trusted_certificate.rb
@@ -1,0 +1,62 @@
+#
+# Cookbook:: chef-client
+# resource:: chef_client_trusted_certificate
+#
+# Copyright:: 2020, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chef_version_for_provides '< 16.5' if respond_to?(:chef_version_for_provides)
+
+provides :chef_client_trusted_certificate
+resource_name :chef_client_trusted_certificate
+
+property :cert_name, String, name_property: true
+
+# this version check can go away once this is ported into chef itself
+property :certificate, String, required: Chef::VERSION.to_i >= 16 ? [:add] : true
+
+action :add do
+  unless ::Dir.exist?(Chef::Config[:trusted_certs_dir])
+    directory Chef::Config[:trusted_certs_dir] do
+      mode '0640'
+      recursive true
+    end
+  end
+
+  file cert_path do
+    content new_resource.certificate
+    mode '0640'
+  end
+end
+
+action :remove do
+  file cert_path do
+    action :delete
+    mode '0640'
+  end
+end
+
+action_class do
+  #
+  # The path to the string on disk
+  #
+  # @return [String]
+  #
+  def cert_path
+    path = ::File.join(Chef::Config[:trusted_certs_dir], new_resource.cert_name)
+    path << '.pem' unless path.end_with?('.pem')
+    path
+  end
+end

--- a/test/cookbooks/test/recipes/config.rb
+++ b/test/cookbooks/test/recipes/config.rb
@@ -3,3 +3,38 @@ node.override['ohai']['optional_plugins'] = ['Passwd']
 node.override['ohai']['plugin_path'] = '/tmp/kitchen/ohai/plugins'
 node.override['chef_client']['chef_license'] = 'accept-no-persist'
 include_recipe 'chef-client::config'
+
+chef_client_trusted_certificate 'self-signed.badssl.com' do
+  certificate <<~CERT
+  -----BEGIN CERTIFICATE-----
+  MIIDeTCCAmGgAwIBAgIJAPziuikCTox4MA0GCSqGSIb3DQEBCwUAMGIxCzAJBgNV
+  BAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNp
+  c2NvMQ8wDQYDVQQKDAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTAeFw0x
+  OTEwMDkyMzQxNTJaFw0yMTEwMDgyMzQxNTJaMGIxCzAJBgNVBAYTAlVTMRMwEQYD
+  VQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ8wDQYDVQQK
+  DAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEB
+  BQADggEPADCCAQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2
+  PmzAS2BMTOqytMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMW
+  hyefdOsKnRFSJiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3A
+  xPxTuW1CrbV8/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqve
+  ww9HdFxBIuGa+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SY
+  QCeFxxC7c3DvaRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaMyMDAwCQYDVR0T
+  BAIwADAjBgNVHREEHDAaggwqLmJhZHNzbC5jb22CCmJhZHNzbC5jb20wDQYJKoZI
+  hvcNAQELBQADggEBAGlwCdbPxflZfYOaukZGCaxYK6gpincX4Lla4Ui2WdeQxE95
+  w7fChXvP3YkE3UYUE7mupZ0eg4ZILr/A0e7JQDsgIu/SRTUE0domCKgPZ8v99k3A
+  vka4LpLK51jHJJK7EFgo3ca2nldd97GM0MU41xHFk8qaK1tWJkfrrfcGwDJ4GQPI
+  iLlm6i0yHq1Qg1RypAXJy5dTlRXlCLd8ufWhhiwW0W75Va5AEnJuqpQrKwl3KQVe
+  wGj67WWRgLfSr+4QG1mNvCZb2CkjZWmxkGPuoP40/y7Yu5OFqxP5tAjj4YixCYTW
+  EVA0pmzIzgBg+JIe3PdRy27T0asgQW/F4TY61Yk=
+  -----END CERTIFICATE-----
+  CERT
+end
+
+# see if we can fetch from our new trusted domain
+remote_file ::File.join(Chef::Config[:file_cache_path], 'index.html') do
+  source 'https://self-signed.badssl.com/index.html'
+end
+
+chef_client_trusted_certificate 'nothing' do
+  action :remove
+end


### PR DESCRIPTION
This is the first take at a simple resource to add trusted certificates
to chef's trusted_certificate directory. This directory is not created
out of the box so we create it if it's missing with 640 perms. For the
moment the resource just takes the cert as a string. Once we build a
file fetching mixin this should allow us to specify the content as a
string or a URI.

Before using this resource fetching `https://self-signed.badssl.com/index.html` within the test cookbook resulted in the following error:

```
       * remote_file[/tmp/kitchen/cache/index.html] action create[2020-08-19T18:48:00+00:00] ERROR: SSL Validation failure connecting to host: self-signed.badssl.com - SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)


           ================================================================================
           Error executing action `create` on resource 'remote_file[/tmp/kitchen/cache/index.html]'
           ================================================================================

           OpenSSL::SSL::SSLError
           ----------------------
           SSL Error connecting to https://self-signed.badssl.com/index.html - SSL_connect returned=1 errno=0 state=error: certificate verify failed (self signed certificate)

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/test/recipes/config.rb

            34: remote_file ::File.join(Chef::Config[:file_cache_path], 'index.html') do
            35:   source 'https://self-signed.badssl.com/index.html'
            36: end
            37:

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/test/recipes/config.rb:34:in `from_file'

           remote_file("/tmp/kitchen/cache/index.html") do
             action [:create]
             default_guard_interpreter :default
             source ["https://self-signed.badssl.com/index.html"]
             declared_type :remote_file
             cookbook_name "test"
             recipe_name "config"
             remote_domain nil
             remote_user nil
             path "/tmp/kitchen/cache/index.html"
             owner nil
             group nil
             headers {}
             mode nil
             verifications []
           end

           System Info:
           ------------
           chef_version=16.4.38
           platform=centos
           platform_version=8.2.2004
           ruby=ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
           program_name=/opt/chef/bin/chef-client
           executable=/opt/chef/bin/chef-client
```

With the chef_client_trusted_cert running to add that certificate it runs without issue:

```
    * remote_file[/tmp/kitchen/cache/index.html] action create
           - create new file /tmp/kitchen/cache/index.html
           - update content in file /tmp/kitchen/cache/index.html from none to 6c8b9f
           --- /tmp/kitchen/cache/index.html	2020-08-19 18:46:46.325612910 +0000
           +++ /tmp/kitchen/cache/.chef-index20200819-6235-mr5mhi.html	2020-08-19 18:46:46.323612895 +0000
           @@ -1 +1,21 @@
           +<!DOCTYPE html>
           +<html>
           +<head>
           +  <meta charset="utf-8">
           +  <meta name="viewport" content="width=device-width, initial-scale=1">
           +  <link rel="shortcut icon" href="/icons/favicon-red.ico"/>
           +  <link rel="apple-touch-icon" href="/icons/icon-red.png"/>
           +  <title>self-signed.badssl.com</title>
           +  <link rel="stylesheet" href="/style.css">
           +  <style>body { background: red; }</style>
           +</head>
           +<body>
           +<div id="content">
           +  <h1 style="font-size: 12vw;">
           +    self-signed.<br>badssl.com
           +  </h1>
           +</div>
           +
           +</body>
           +</html>
           - restore selinux security context
```

Signed-off-by: Tim Smith <tsmith@chef.io>