### PR TITLE
Simplify the launchd recipe

### DIFF
--- a/recipes/launchd_service.rb
+++ b/recipes/launchd_service.rb
@@ -3,20 +3,13 @@ class ::Chef::Recipe
   include ::Opscode::ChefClient::Helpers
 end
 
-require 'chef/version_constraint'
-
-# libraries/helpers.rb method to DRY directory creation resources
-client_bin = find_chef_client
-Chef::Log.debug("Using chef-client binary at #{client_bin}")
-node.default['chef_client']['bin'] = client_bin
-
 create_chef_directories
 
 template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
   source 'com.chef.chef-client.plist.erb'
   mode '0644'
   variables(
-    client_bin: client_bin,
+    client_bin: node['chef_client']['bin'] || '/opt/chef/bin/chef-client',
     daemon_options: node['chef_client']['daemon_options'],
     interval: node['chef_client']['interval'],
     launchd_mode: node['chef_client']['launchd_mode'],
@@ -25,15 +18,10 @@ template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
     splay: node['chef_client']['splay'],
     working_dir: node['chef_client']['launchd_working_dir']
   )
-  notifies :restart, 'macosx_service[com.chef.chef-client]' if node['chef_client']['launchd_self-update']
+  notifies :restart, 'launchd[com.chef.chef-client]' if node['chef_client']['launchd_self-update']
 end
 
-macosx_service 'com.chef.chef-client' do
-  action :nothing
-end
-
-macosx_service 'chef-client' do
-  service_name 'com.chef.chef-client'
-  plist '/Library/LaunchDaemons/com.chef.chef-client.plist'
-  action :start
+launchd 'com.chef.chef-client' do
+  path '/Library/LaunchDaemons/com.chef.chef-client.plist'
+  action [:create, :enable]
 end

--- a/resources/launchd.rb
+++ b/resources/launchd.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook:: chef-client
+# Resource:: chef_client_launchd
+#
+# Copyright:: Chef Software, Inc.
+#
+
+resource_name :chef_client_launchd
+provides :chef_client_launchd
+
+property :interval, Integer, default: 30, description: 'Time in minutes between Chef Infra Client executions'
+
+action :enable do
+  template '/Library/LaunchDaemons/com.chef.chef-client.plist' do
+    cookbook 'desktop-config'
+    source 'com.chef.chef-client.plist.erb'
+    owner 'root'
+    group 'wheel'
+    mode '0644'
+    variables(
+      interval: new_resource.interval * 60
+    )
+  end
+
+  launchd 'com.chef.chef-client' do
+    path '/Library/LaunchDaemons/com.chef.chef-client.plist'
+    action [:create, :enable]
+  end
+end
+
+action :disable do
+  service 'chef-client' do
+    service_name 'com.chef.chef-client'
+    action :disable
+  end
+end

--- a/spec/unit/launchd_service_spec.rb
+++ b/spec/unit/launchd_service_spec.rb
@@ -8,16 +8,17 @@ describe 'chef-client::launchd_service' do
       end.converge(described_recipe)
     end
 
-    it 'creates the launch daemon' do
+    it 'creates the launchd daemon plist' do
       expect(chef_run).to create_template('/Library/LaunchDaemons/com.chef.chef-client.plist')
     end
 
-    it 'reloads the launch daemon' do
-      expect(chef_run).to start_macosx_service('com.chef.chef-client')
+    it 'create / enable the launchd daemon' do
+      expect(chef_run).to create_launchd('com.chef.chef-client')
+      expect(chef_run).to enable_launchd('com.chef.chef-client')
     end
 
-    it 'restarts the service when daemon is changed' do
-      expect(chef_run.template('/Library/LaunchDaemons/com.chef.chef-client.plist')).to notify('macosx_service[com.chef.chef-client]').to(:restart)
+    it 'restarts the launchd daemon when template is changed' do
+      expect(chef_run.template('/Library/LaunchDaemons/com.chef.chef-client.plist')).to notify('launchd[com.chef.chef-client]').to(:restart)
     end
   end
 end
@@ -30,16 +31,17 @@ describe 'chef-client::launchd_service' do
       end.converge(described_recipe)
     end
 
-    it 'creates the launch daemon' do
+    it 'creates the launch daemon plist' do
       expect(chef_run).to create_template('/Library/LaunchDaemons/com.chef.chef-client.plist')
     end
 
-    it 'reloads the launch daemon' do
-      expect(chef_run).to start_macosx_service('com.chef.chef-client')
+    it 'create / enable the launchd daemon' do
+      expect(chef_run).to create_launchd('com.chef.chef-client')
+      expect(chef_run).to enable_launchd('com.chef.chef-client')
     end
 
     it 'does not restart the service when daemon is changed' do
-      expect(chef_run.template('/Library/LaunchDaemons/com.chef.chef-client.plist')).to_not notify('macosx_service[com.chef.chef-client]')
+      expect(chef_run.template('/Library/LaunchDaemons/com.chef.chef-client.plist')).to_not notify('launchd[com.chef.chef-client]')
     end
   end
 end


### PR DESCRIPTION
- Stop relying on the legacy find_chef_client helper. Use the node attribute or '/opt/chef/bin/chef-client'. Avoid complex find logic that was only necessary for gem install
- Use launchd resource, not macosx_service, which we added in 12.8

Signed-off-by: Tim Smith <tsmith@chef.io>