### PR TITLE
Make the onbootsec parameter to attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,7 @@ default['chef_client']['chef_license'] = nil
 default['chef_client']['log_file']    = 'client.log'
 default['chef_client']['interval']    = '1800'
 default['chef_client']['splay']       = '300'
+default['chef_client']['delay_after_boot'] = '60'
 default['chef_client']['conf_dir']    = '/etc/chef'
 default['chef_client']['bin']         = '/opt/chef/bin/chef-client'
 

--- a/recipes/systemd_service.rb
+++ b/recipes/systemd_service.rb
@@ -81,7 +81,7 @@ systemd_unit 'chef-client.timer' do
     'Unit' => { 'Description' => 'chef-client periodic run' },
     'Install' => { 'WantedBy' => 'timers.target' },
     'Timer' => {
-      'OnBootSec' => '1min',
+      'OnBootSec' => "#{node['chef_client']['delay_after_boot']}sec",
       'OnUnitInactiveSec' => "#{node['chef_client']['interval']}sec",
       'RandomizedDelaySec' => "#{node['chef_client']['splay']}sec",
     }

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -27,7 +27,7 @@ property :description, String, default: 'Chef Infra Client periodic execution'
 
 property :user, String, default: 'root'
 
-property :delay_after_boot, String, default: '1min'
+property :delay_after_boot, String, default: '60sec'
 property :interval, String, default: '30min'
 property :splay, [Integer, String], default: 300,
                                     coerce: proc { |x| Integer(x) },

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -27,7 +27,7 @@ property :description, String, default: 'Chef Infra Client periodic execution'
 
 property :user, String, default: 'root'
 
-property :delay_after_boot, String, default: '60sec'
+property :delay_after_boot, String, default: '1min'
 property :interval, String, default: '30min'
 property :splay, [Integer, String], default: 300,
                                     coerce: proc { |x| Integer(x) },

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -27,7 +27,7 @@ property :description, String, default: 'Chef Infra Client periodic execution'
 
 property :user, String, default: 'root'
 
-property :delay_after_boot, String, default: '60Sec'
+property :delay_after_boot, String, default: '1min'
 property :interval, String, default: '30min'
 property :splay, [Integer, String], default: 300,
                                     coerce: proc { |x| Integer(x) },

--- a/resources/systemd_timer.rb
+++ b/resources/systemd_timer.rb
@@ -27,7 +27,7 @@ property :description, String, default: 'Chef Infra Client periodic execution'
 
 property :user, String, default: 'root'
 
-property :delay_after_boot, String, default: '1min'
+property :delay_after_boot, String, default: '60Sec'
 property :interval, String, default: '30min'
 property :splay, [Integer, String], default: 300,
                                     coerce: proc { |x| Integer(x) },

--- a/test/integration/timer_systemd/timer_systemd_spec.rb
+++ b/test/integration/timer_systemd/timer_systemd_spec.rb
@@ -7,7 +7,7 @@ end
 
 control 'has expected unit content' do
   describe file('/etc/systemd/system/chef-client.timer') do
-    its('content') { should match 'OnBootSec = 1min' }
+    its('content') { should match 'OnBootSec = 60sec' }
     its('content') { should match 'OnUnitInactiveSec = 1800sec' }
     its('content') { should match 'RandomizedDelaySec = 300sec' }
   end


### PR DESCRIPTION
This is to make the OnBootSec parameter to control via attribute when the chef-client runs as a timer service,

### Description
This is to make the OnBootSec parameter to control via attribute when the chef-client runs as a timer service.
There are cases chef-client run after the boot is elapsed, becuase of the default 1min and there should be a mechanism to control this parameter. 
Changing this parameter to hgher value seems to be fixing this and should be control it via attribute, keeping 1 min as default.

### Issues Resolved
There are cases chef-client run after the boot is elapsed, becuase of the default 1min and there should be a mechanism to control this parameter. 
Changing this parameter to higher value seems to be fixing this and should be control it via attribute, keeping 1 min as default.


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>