### PR TITLE
Fix functionality of append_log_file parameter for Chef 15 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef-client cookbook.
 
+## Unreleased
+
+- Fix functionality of append_log_file parameter for Chef 15 and below
+
 ## 12.2.0 (2020-08-26)
 
 - chef_client_cron: Add nice property to control nice level of the chef-client process - [@tas50](https://github.com/tas50)

--- a/resources/cron.rb
+++ b/resources/cron.rb
@@ -105,7 +105,12 @@ action_class do
   #
   def log_command
     if new_resource.append_log_file
-      "-L #{::File.join(new_resource.log_directory, new_resource.log_file_name)}"
+      # Chef 15 and lower still sends output to stdout when -L is used
+      if Gem::Requirement.new('< 16.0.0').satisfied_by?(Gem::Version.new(Chef::VERSION))
+        ">> #{::File.join(new_resource.log_directory, new_resource.log_file_name)} 2>&1"
+      else
+        "-L #{::File.join(new_resource.log_directory, new_resource.log_file_name)}"
+      end
     else
       "> #{::File.join(new_resource.log_directory, new_resource.log_file_name)} 2>&1"
     end


### PR DESCRIPTION
In Chef 15 and below, using -L for sending log output also sends the output to
stdout which is not how the previous version of this cookbook worked. Currently,
all output it sent to cron email which is not wanted.

This provides a fix for users of older Chef versions and restores the previous
functionality of redirecting the output to a logfile.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>