### PR TITLE
chef-client stop init.d service stopping other process fixes

### DIFF
--- a/templates/default/redhat/init.d/chef-client.erb
+++ b/templates/default/redhat/init.d/chef-client.erb
@@ -43,6 +43,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
+    ps -ef |grep $exec |grep -v grep |awk '{print $2}' > $pidfile
     killproc -p $pidfile $exec
     retval=$?
     echo


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
- Fixed stop init.d service stopping other process issue.

### Issues Resolved
[#221](https://github.com/chef/customer-bugs/issues/221)

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>