### PR TITLE
Pin logrotate to a version that supports chef 13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version           '12.3.4'
 end
 
 depends 'cron', '>= 4.2.0'
-depends 'logrotate', '>= 1.9.0', '<= 3.0.0'
+depends 'logrotate', '>= 1.9.0', '< 3.0.0'
 
 source_url 'https://github.com/chef-cookbooks/chef-client'
 issues_url 'https://github.com/chef-cookbooks/chef-client/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version           '12.3.4'
 end
 
 depends 'cron', '>= 4.2.0'
-depends 'logrotate', '>= 1.9.0'
+depends 'logrotate', '>= 1.9.0', '<= 3.0.0'
 
 source_url 'https://github.com/chef-cookbooks/chef-client'
 issues_url 'https://github.com/chef-cookbooks/chef-client/issues'


### PR DESCRIPTION
Pins logrotate to a version that supports chef 13.

Edit: I see this was discussed previously in #734. Perhaps the minimum supported version of chef should be updated to 15.3?